### PR TITLE
feat: add favorite restaurant order function

### DIFF
--- a/src/pages/account/restaurant/favorite/index.tsx
+++ b/src/pages/account/restaurant/favorite/index.tsx
@@ -15,13 +15,6 @@ interface Restaurant {
 }
 
 export default function Setting_Favorite() {
-  // Favorite 로직 나오기 전까지는 동작 안하게 설정
-  const router = useRouter();
-  useEffect(() => {
-    router.push("/account");
-  }, []);
-  return <></>;
-
   const state = useStateContext();
 
   const [orderData, setOrderData] = useState<Restaurant[]>([]);
@@ -33,15 +26,19 @@ export default function Setting_Favorite() {
       const {
         data: { result },
       }: { data: { result: Restaurant[] } } = await axios.get(`${APIendpoint()}/restaurants/`);
-      // Todo: 즐겨차기 리스트 완성되면 localStorage에서 가져오기
+      const favoriteList = JSON.parse(localStorage.getItem("favorite_restaurant") ?? "[]");
+
       for (let i = 0; i < orderList.length; i++) {
-        if (!result.find(({ id }) => id === orderList[i].id)) {
+        if (
+          !result.find(({ id }) => id === orderList[i].id) ||
+          !favoriteList.includes(orderList[i].id)
+        ) {
           orderList.splice(i, 1);
           i--;
         }
       }
       result.forEach(({ id, name_kr, name_en }) => {
-        if (!orderList.some((menu) => Number(menu.id) === id))
+        if (!orderList.some((menu) => Number(menu.id) === id) && favoriteList.includes(id))
           orderList.push({ id, name_kr, name_en });
       });
 


### PR DESCRIPTION
### Summary

favorite 기능 추가에 맞춰 기존에 미구현으로 뒀던 즐겨찾기 식당에서의 정렬 기능을 추가했습니다.

### Tech

- 좋아요 정보는 현재 localStorage에서 가져옵니다.
- 즐겨찾기 삭제시에도 순서는 유지되고, 임의의 식당을 즐겨찾기 추가시 해당 식당은 제일 밑에 배치됩니다.
  - 이부분 구현을 위해 iOS 앱 참고해봤는데, iOS의 경우는 직전의 정렬데이터가 있을경우 해당 데이터를 참고하고, 없을경우 이전까지의 정렬데이터를 무시하고 가나다순으로 다시 정렬합니다.
  - 이보다는 정렬 순서를 유지하는 쪽이 직관적이고 구현에도 도움이 된다 생각해서 순서를 최대한 유지하는 쪽으로 결정했습니다!