### PR TITLE
feature/desktop-favorite-order

### DIFF
--- a/src/components/RestaurantList.tsx
+++ b/src/components/RestaurantList.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { useStateContext } from "hooks/ContextProvider";
-import { use, useEffect } from "react";
+import { useEffect, useState } from "react";
 import useFavorite from "hooks/UseFavorite";
 
 function scrollRestaurant(restaurant) {
@@ -16,13 +16,22 @@ export default function RestaurantList() {
 
   const { meal, data } = state;
 
-  const { toggleFavorite, isFavorite } = useFavorite();
+  const { favoriteRestaurant, toggleFavorite, isFavorite } = useFavorite();
+  const [ favoriteFirstRestaurants, setFavoriteFirstRestaurants] = useState<Array<any>>([]);
+
+  useEffect(() => {
+    const favorites = data[meal].filter(restaurant => isFavorite(restaurant.id))
+    const nonFavorites = data[meal].filter(restaurant => isFavorite(restaurant.id) === false)
+
+    const newFavoriteFirstRestaurants = favorites.concat(nonFavorites);
+    setFavoriteFirstRestaurants(newFavoriteFirstRestaurants);
+  }, [data, favoriteRestaurant]);
 
   return (
     <Container>
       <Restaurants>
-        {data[meal] &&
-          data[meal].map((restaurant) => (
+        {favoriteFirstRestaurants &&
+          favoriteFirstRestaurants.map((restaurant) => (
             <Restaurant key={restaurant.id}>
               <RestaurantName onClick={() => scrollRestaurant(restaurant.code)}>
                 {restaurant.name_kr}


### PR DESCRIPTION
### Summary

desktop에서 좌측 하단 식당 목록의 순서를 즐겨찾기 식당이 상단에 위치하도록 바꿨습니다.

### Tech

`Restaurant` component에 즐겨찾기 식당이 앞에 위치하도록 재배열된 식당 목록을 저장하는 `favoriteFirstRestaurants` state를 추가했습니다. 식당 정보(`data`)나 즐겨찾기 식당 목록(`favoriteRestaurant`)이 변경될 때마다 해당 state를 갱신하였고, `data[meal]` 대신 해당 state의 element를 출력함으로써 기능을 구현했습니다.