### PR TITLE
fix: fix options layout in comment writer

### DIFF
--- a/src/components/Community/CommentWriter.tsx
+++ b/src/components/Community/CommentWriter.tsx
@@ -55,6 +55,8 @@ export default function CommentWriter({ postId, update }: CommentWriterProps) {
 }
 
 const Container = styled.div`
+  display: flex;
+  align-items: center;
   position: sticky;
   padding-top: 18.7px;
   padding-bottom: 24.7px;
@@ -90,9 +92,7 @@ const CommentInput = styled.input`
 
 const Options = styled.div`
   position: absolute;
-  top: 50%;
   right: 0;
-  transform: translateY(-50%);
 
   padding: 0 6.5px;
 


### PR DESCRIPTION
### Summary

`CommentWriter` component의 `options`가 세로로 정가운데에 오도록 했습니다

### Tech

`display: flex`, `align-items: center` option을 이용해 가운데 정렬을 했습니다.