### PR TITLE
Fix/profile api

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -195,9 +195,7 @@ export interface RawUser {
   type: string;
   identity: string;
   nickname: string;
-  etc: {
-    image?: string;
-  } | null;
+  profile_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/utils/api/auth.ts
+++ b/src/utils/api/auth.ts
@@ -121,9 +121,9 @@ export const getMyData = async (accessToken: string): Promise<User> => {
     })
     .then((res: { data: RawUser }) => {
       const {
-        data: { id, nickname, etc },
+        data: { id, nickname, profile_url },
       } = res;
-      return { id, nickname, image: etc?.image ?? null };
+      return { id, nickname, image: profile_url };
     })
     .catch((e) => {
       throw new Error(e);
@@ -131,6 +131,9 @@ export const getMyData = async (accessToken: string): Promise<User> => {
 };
 
 export const updateMyData = async (formData: FormData, accessToken: string): Promise<User> => {
+  if (!formData.get("nickname")) {
+    throw new Error("nickname is required");
+  }
   return axios
     .patch(`${APIendpoint()}/auth/me/profile`, formData, {
       headers: {
@@ -140,9 +143,9 @@ export const updateMyData = async (formData: FormData, accessToken: string): Pro
     })
     .then((res: { data: RawUser }) => {
       const {
-        data: { id, nickname, etc },
+        data: { id, nickname, profile_url },
       } = res;
-      return { id, nickname, image: etc?.image ?? null };
+      return { id, nickname, image: profile_url };
     })
     .catch((e) => {
       throw new Error(e);


### PR DESCRIPTION
### Summary

-프로필 이미지 관련 api 수정

### Tech

- 기존까지는 etc 객체에서 profile_url 속성을 가져왔는데, 직접 내려주는것으로 바뀌어 이에 맞게 수정했습니다
  - 직접 요청을 테스트해보니 실제 type은 string | null입니다. 프로필 이미지를 설정하지 않은경우 null이 되네요.
- conflict 방지를 위해 prod에서 feat/firebase로 한번 pull을 땡겼는데, 이 이유때문에 #110 PR Merge 이후 merge해야할거 같습니다!