### PR TITLE
fix: post에서 제목과 콘텐츠가 잘리는 문제

### DIFF
--- a/src/pages/community/boards/[boardId]/posts/[postId].tsx
+++ b/src/pages/community/boards/[boardId]/posts/[postId].tsx
@@ -312,11 +312,15 @@ const MobileMoreActionsButton = styled.img`
 
 const Content = styled.div`
   margin-bottom: 15.5px;
+  word-wrap: break-word;
 `;
 const Title = styled.div`
   font-weight: 700;
   font-size: 20px;
   margin-bottom: 30px;
+  width: 100%;
+  word-wrap: break-word;
+
   @media (max-width: 768px) {
     font-weight: 800;
     font-size: 16px;


### PR DESCRIPTION
### Summary

post에서 제목과 콘텐츠가 잘리는 문제를 해결했습니다.
<img width="778" alt="스크린샷 2024-08-14 오후 5 30 46" src="https://github.com/user-attachments/assets/44a5d667-b706-4930-8b3b-f776de03e18b">

### Tech

기술적인 세부사항을 적어주세요.