### PR TITLE
fix: post 미리보기에서 들여쓰기 되지 않게

### DIFF
--- a/src/components/Community/Post.tsx
+++ b/src/components/Community/Post.tsx
@@ -91,6 +91,7 @@ const Title = styled.div`
   overflow: hidden;
   font-size: 18px;
   font-weight: bold;
+  white-space: nowrap;
   text-overflow: ellipsis;
   @media (max-width: 768px) {
     font-size: 12px;
@@ -99,6 +100,7 @@ const Title = styled.div`
 const ContentPreview = styled.div`
   color: #393939;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   @media (max-width: 768px) {
     font-size: 12px;


### PR DESCRIPTION
### Summary

post 미리보기에서 글이 들여쓰기되어 미리보기가 방대해지는 이슈를 해결했습니다.

### Tech

<img width="580" alt="스크린샷 2024-08-15 오후 9 04 01" src="https://github.com/user-attachments/assets/59fc87b0-4eca-47d9-a03f-e57980678c7d">
