### PR TITLE
fix: more flexible responsivity

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,19 +15,10 @@ export default function Header() {
   return (
     <Background>
       <Container>
-        <SikshaIcon
-          src={"/img/sikshaSplash.svg"}
-          onClick={() => {
-            router.push("/");
-          }}
-        />
-        <Title
-          onClick={() => {
-            router.push("/");
-          }}
-        >
-          서울대학교 식단 알리미
-        </Title>
+        <CIContainer>
+          <SikshaIcon src={"/img/sikshaSplash.svg"} onClick={() => router.push("/")} />
+          <Title onClick={() => router.push("/")}>서울대학교 식단 알리미</Title>
+        </CIContainer>
         <NavigationBar />
         {authStatus === "login" ? (
           <LoginButton onClick={logout}>로그아웃</LoginButton>
@@ -38,39 +29,17 @@ export default function Header() {
     </Background>
   );
 }
-const LoginButton = styled.div`
-  position: absolute;
-  right: 97px;
-  bottom: 23px;
-  background: none;
-  font-size: 20px;
-  font-weight: 400;
-  color: #ffffff;
-  cursor: pointer;
-
-  @media (max-width: 768px) {
-    position: absolute;
-    right: 5vw;
-    font-size: 16px;
-    top: 21px;
-  }
-`;
 
 const Background = styled.div`
   background: #ff9522;
-  min-width: 1920px;
-  @media (max-width: 768px) {
-    min-width: 0;
-  }
 `;
 
 const Container = styled.div`
   position: relative;
   height: 271px;
-  width: 1920px;
   box-sizing: border-box;
   display: flex;
-  padding-left: 258px;
+  justify-content: space-evenly;
   margin: auto;
 
   @media (max-width: 768px) {
@@ -80,6 +49,10 @@ const Container = styled.div`
     top: 0;
     z-index: 1;
   }
+`;
+
+const CIContainer = styled.div`
+  display: flex;
 `;
 
 const SikshaIcon = styled.img`
@@ -114,13 +87,23 @@ const Title = styled.div`
     display: none;
   }
 `;
-// const NavBarContainer = styled.div`
-//   width: 100%;
-//   display: flex;
-//   align-items: flex-end;
-//   justify-content: center;
-//   margin-right: 368px;
-//   @media (max-width: 768px) {
-//     display: none;
-//   }
-// `;
+
+const LoginButton = styled.button`
+  margin-top: auto;
+  padding-bottom: 21.5px;
+  background: none;
+  font-size: 20px;
+  font-weight: 400;
+  border: none;
+  outline: none;
+  color: #ffffff;
+  cursor: pointer;
+  white-space: nowrap;
+
+  @media (max-width: 768px) {
+    position: absolute;
+    right: 5vw;
+    font-size: 16px;
+    top: 21px;
+  }
+`;

--- a/src/components/LeftSide.tsx
+++ b/src/components/LeftSide.tsx
@@ -60,7 +60,7 @@ const Container = styled.div`
   margin-right: 18px;
   height: fit-content;
   box-sizing: border-box;
-  min-width: 400px;
+  min-width: 315px;
   max-width: 563px;
   flex-grow: 1;
 `;

--- a/src/components/MenuDetail/MenuSection.tsx
+++ b/src/components/MenuDetail/MenuSection.tsx
@@ -100,7 +100,7 @@ export default function MenuSection({
 const MenuContainer = styled.section`
   position: relative;
   background-color: white;
-  width: 1185px;
+  width: 897px;
   height: 100%;
   @media (max-width: 768px) {
     flex-grow: 0;
@@ -111,9 +111,8 @@ const MenuContainer = styled.section`
 `;
 
 const MenuInfoContainer = styled.div`
-  padding: 41px 30px 26px 258px;
-  width: 897px;
-  margin-left: auto;
+  padding: 41px 30px 26px 0px;
+
   @media (max-width: 768px) {
     padding: 18px 15px 16px 17px;
     width: auto;

--- a/src/components/MenuDetail/ReviewPostModal.tsx
+++ b/src/components/MenuDetail/ReviewPostModal.tsx
@@ -168,7 +168,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 735px;
+  width: 735px;
   border-left: 1px solid #eeeeee;
   padding-left: 37px;
   padding-right: 36px;

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -3,18 +3,18 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useStateContext } from "../hooks/ContextProvider";
 import useModals from "hooks/UseModals";
-import LoginModal from "./Auth/LoginModal";
+import useAuth from "hooks/UseAuth";
 
+// directory 변경 필요
 export default function NavigationBar() {
   const router = useRouter();
   const addr = router.pathname;
 
-  const state = useStateContext();
-  const { loginStatus } = state;
+  const { authStatus } = useAuth();
   const { openLoginModal } = useModals();
 
-  const onToggleAccount = () => {
-    if (!loginStatus) openLoginModal();
+  const toggleAccount = () => {
+    if (authStatus === "logout") openLoginModal();
     else router.push(`/account`);
   };
 
@@ -30,7 +30,7 @@ export default function NavigationBar() {
           <NavLink $cur={addr.startsWith(`/community`)}>게시판</NavLink>
         </Link>
       </NavItem>
-      <NavItem onClick={onToggleAccount}>
+      <NavItem onClick={toggleAccount}>
         <NavLink $cur={addr.startsWith(`/account`)}>마이 페이지</NavLink>
       </NavItem>
     </NaviBar>
@@ -39,8 +39,6 @@ export default function NavigationBar() {
 
 const NaviBar = styled.nav`
   margin-top: auto;
-  margin-left: 325px;
-  margin-right: 386px;
   width: 394px;
   white-space: nowrap;
   cursor: pointer;

--- a/src/components/RightSide.tsx
+++ b/src/components/RightSide.tsx
@@ -18,7 +18,6 @@ const Container = styled.div`
   justify-content: flex-start;
   margin-left: 18px;
   box-sizing: border-box;
-  min-width: 785px;
   max-width: 818px;
   height: 100%;
   flex-grow: 1;

--- a/src/components/general/Layout.tsx
+++ b/src/components/general/Layout.tsx
@@ -47,7 +47,6 @@ export default function Layout({ children }: LayoutProps) {
 
 const Container = styled.div`
   width: 100%;
-  min-width: 1920px;
   height: 100dvh;
   @media (max-width: 768px) {
     min-width: 0;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -102,7 +102,6 @@ const DesktopContainer = styled.div`
   display: flex;
   justify-content: center;
   height: max(780px, 100vh - min(25vh, 271px));
-  width: min(73vw, 1417px);
   margin: 39px auto 0 auto;
 
   @media (max-width: 768px) {

--- a/src/pages/menu/[menuId].tsx
+++ b/src/pages/menu/[menuId].tsx
@@ -190,9 +190,10 @@ const Info = styled.div`
   position: relative;
   background-color: white;
   display: flex;
+  justify-content: center;
   height: max(809px, calc(100vh - 271px));
-  width: fit-content;
-  margin: auto;
+  width: 100%;
+  margin: 0 auto;
   @media (max-width: 768px) {
     flex-direction: column;
     height: max(724px, calc(100vh - 60px));

--- a/src/styles/globalstyle.tsx
+++ b/src/styles/globalstyle.tsx
@@ -46,7 +46,6 @@ export const GlobalStyle = createGlobalStyle`
     background: #F8F8F8;
     -ms-overflow-style: none;
     font-family: NanumSquare, sans-serif;
-    min-width: 1221px;
 
     @media (max-width: 768px) {
       min-width: 0;


### PR DESCRIPTION
### Summary

더욱 자연스러운 반응형 레이아웃을 만들었습니다. 기존의 레이아웃은 1920px width에 맞춰져, 화면이 작아졌을 때 화면상 요소들이 잘려 보였습니다. 화면 크기가 작아지거나 커졌을 때, 보다 자연스럽게 요소들을 배치할 수 있도록 수정하였습니다. 아래는 참고 영상입니다.


https://github.com/user-attachments/assets/e695d253-d595-45b5-8009-3f8cca6ea21f


https://github.com/user-attachments/assets/894f4a2a-cbf0-4667-b737-4d8547b74b93


https://github.com/user-attachments/assets/63bdceb4-e3b6-49cb-8444-c32415d9d94c


https://github.com/user-attachments/assets/d68f2bc8-d2da-4c46-8566-3106f40ce016


https://github.com/user-attachments/assets/bcf055d9-74f8-48eb-9999-873c0ccf22db


### Tech
