### PR TITLE
fix: fix restaurant order in favorite && order loading

### DIFF
--- a/src/components/RestaurantList.tsx
+++ b/src/components/RestaurantList.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import { useStateContext } from "hooks/ContextProvider";
 import { useEffect, useState } from "react";
 import useFavorite from "hooks/UseFavorite";
-import { LoadingAnimation } from "styles/globalstyle";
 
 function scrollRestaurant(restaurant) {
   let element = document.querySelector(".a" + restaurant);

--- a/src/components/general/Layout.tsx
+++ b/src/components/general/Layout.tsx
@@ -29,8 +29,9 @@ export default function Layout({ children }: LayoutProps) {
       .then((newAccessToken) => {
         login(newAccessToken);
       })
-      .catch((res) => {
-        console.error(res);
+      .catch((error) => {
+        const { message } = error;
+        if (message !== "Login required") console.error(error);
       });
   }, []);
 

--- a/src/hooks/UseProfile.ts
+++ b/src/hooks/UseProfile.ts
@@ -9,7 +9,6 @@ export default function UseProfile() {
   const { getAccessToken, authStatus } = useAuth();
 
   useEffect(() => {
-    console.log(authStatus)
     if (authStatus === "loading") return;
     if (authStatus === "logout") {
       setUserInfo(null);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,10 +19,10 @@ export default function Home() {
   const state = useStateContext();
   const { setLoading, setData } = useDispatchContext();
 
-  const { date, showCal, showInfo, meal } = state;
+  const { date, showCal, showInfo, meal, isFilterFavorite } = state;
 
   const { authStatus, getAccessToken } = useAuth();
-  const { orderList } = useOrder("nonFavorite");
+  const { orderList } = useOrder(isFilterFavorite ? "favorite" : "nonFavorite");
   const { isExceptEmpty } = useIsExceptEmpty();
 
   useEffect(() => {
@@ -44,6 +44,9 @@ export default function Home() {
           })
           .catch((e) => {
             console.error(e);
+          })
+          .finally(() => {
+            setLoading(false);
           });
       } else {
         getMenuList(dateString, isExceptEmpty, accessToken)
@@ -65,12 +68,15 @@ export default function Home() {
           })
           .catch((e) => {
             console.error(e);
+          })
+          .finally(() => {
+            setLoading(false);
           });
       }
-      setLoading(false);
     }
+
     fetchData();
-  }, [date, authStatus, meal]);
+  }, [date, authStatus, meal, isFilterFavorite]);
 
   return (
     <>


### PR DESCRIPTION
### Summary

- 식단 순서가 모바일 즐겨찾기 페이지에서 반영되지 않는 문제 해결

### Tech

- 메인(src/pages/index.tsx)에서 useFavorite 함수를 가져올 때 isFilterFavorite를 확인하도록 수정
- 수정 과정에서 메뉴 로딩상태를 반영하는 setLoading state가 정상적으로 반영되지 않는 문제를 발견하고 수정
- 그 외 사소한 수정
  - src/components/RestaurantList.tsx: 사용되지 않는 import문 삭제
  -  src/components/general/Layout.tsx layout에서 오류가 아닌 단순히 로그인이 되지 않았을시에는 console.error가 나오지 않도록 수정
  - src/hooks/UseProfile: console.log문 삭제