### PR TITLE
fix: disable break line in my post when postlength is zero

### DIFF
--- a/src/pages/account/mypost/index.tsx
+++ b/src/pages/account/mypost/index.tsx
@@ -38,7 +38,7 @@ export default function MyPost() {
           <Container>
             <Header>내가 쓴 글</Header>
             <PostList posts={posts} fetch={fetchMyPosts} />
-            <BreakLine />
+            {posts.length >= 1 ? <BreakLine /> : null}
           </Container>
         </AccountLayout>
       </>


### PR DESCRIPTION
### Summary

- 내가 쓴 글에서 글이 없을때 선이 하나 남는 문제 해결

### Tech

- 글이 0개인 경우 하단 BreakLine이 보이지 않게 수정했습니다.