### PR TITLE
Fix: fix margin-top & width of container for restaurant order editor

### DIFF
--- a/src/pages/account/restaurant/favorite/index.tsx
+++ b/src/pages/account/restaurant/favorite/index.tsx
@@ -72,9 +72,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 36.92px;
+  width: 100%;
 
   @media (max-width: 768px) {
     margin-top: 0px;
+    height: calc(100% - 60px);
   }
 `;

--- a/src/pages/account/restaurant/index.tsx
+++ b/src/pages/account/restaurant/index.tsx
@@ -68,10 +68,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 36.92px;
+  width: 100%;
 
   @media (max-width: 768px) {
     margin-top: 0px;
-    height: 100%;
+    height: calc(100% - 60px);
   }
 `;


### PR DESCRIPTION
### Summary

식당 순서 변경 페이지에서, desktop layout에서의 margin-top 값을 figma와 동일하게 맞추고 mobile layout에서의 width를 100%로 수정했습니다. container의 높이도 수정했습니다.

### Tech