### PR TITLE
Fix: show liked icon for liked post

### DIFF
--- a/src/components/Community/BoardHeader.tsx
+++ b/src/components/Community/BoardHeader.tsx
@@ -51,21 +51,24 @@ export function BoardHeader() {
         <PostSwiperViewport ref={emblaRef}>
           <PostSwiperContainer>
             {trendingPosts.length > 0 ? (
-              trendingPosts.map((trendingPost) => (
-                <Link
-                  key={trendingPost.id}
-                  href={`/community/boards/${trendingPost.boardId}/posts/${trendingPost.id}`}
-                >
-                  <TrendingPost>
-                    <Title>{trendingPost.title}</Title>
-                    <ContentPreview>{trendingPost.content}</ContentPreview>
-                    <Likes>
-                      <Icon src="/img/post-like.svg" alt="좋아요" />
-                      {trendingPost.likeCount}
-                    </Likes>
-                  </TrendingPost>
-                </Link>
-              ))
+              trendingPosts.map((trendingPost) => {
+                const isLikedImg = trendingPost.isLiked ? "/img/post-like-fill.svg" : "/img/post-like.svg";
+                return (
+                  <Link
+                    key={trendingPost.id}
+                    href={`/community/boards/${trendingPost.boardId}/posts/${trendingPost.id}`}
+                  >
+                    <TrendingPost>
+                      <Title>{trendingPost.title}</Title>
+                      <ContentPreview>{trendingPost.content}</ContentPreview>
+                      <Likes>
+                        <Icon src={isLikedImg} alt="좋아요" />
+                        {trendingPost.likeCount}
+                      </Likes>
+                    </TrendingPost>
+                  </Link>
+                )
+              })
             ) : (
               <NoTrendingPostsMessage>아직 인기 게시글이 없습니다.</NoTrendingPostsMessage>
             )}

--- a/src/components/Community/Post.tsx
+++ b/src/components/Community/Post.tsx
@@ -8,7 +8,8 @@ interface PropsPost {
 }
 
 export function Post({ post }: PropsPost) {
-  const { boardId, id, title, content, likeCount, commentCount, images } = post;
+  const { boardId, id, title, content, isLiked, likeCount, commentCount, images } = post;
+  const isLikedImg = isLiked ? "/img/post-like-fill.svg" : "/img/post-like.svg";
 
   return (
     <Link href={`/community/boards/${boardId}/posts/${id}`}>
@@ -18,7 +19,7 @@ export function Post({ post }: PropsPost) {
           <ContentPreview>{content}</ContentPreview>
           <LikesAndComments>
             <Likes>
-              <Icon src="/img/post-like.svg" alt="좋아요" />
+              <Icon src={isLikedImg} alt="좋아요" />
               {likeCount}
             </Likes>
             <Comments>

--- a/src/pages/community/boards/[boardId]/posts/[postId].tsx
+++ b/src/pages/community/boards/[boardId]/posts/[postId].tsx
@@ -121,6 +121,7 @@ export default function Post() {
   }, [boardId, postId]);
 
   if (post) {
+    const isLikedImg = post.isLiked ? "/img/post-like-fill.svg" : "/img/post-like.svg";
     const likeButtonIcon = post.isLiked ? "/img/post-like-white.svg" : "/img/post-like.svg";
     const profileImg = post.profileUrl || "/img/default-profile.svg";
 
@@ -180,7 +181,7 @@ export default function Post() {
             </Content>
             <LikesAndComments>
               <Likes>
-                <Icon src="/img/post-like.svg" alt="좋아요" />
+                <Icon src={isLikedImg} alt="좋아요" />
                 {post.likeCount}
               </Likes>
               <Comments>


### PR DESCRIPTION
### Summary

좋아요를 누른 게시물에 `/img/post-like.svg` 대신 `/img/post-like-fill.svg` 아이콘을 사용하도록 했습니다.

### Tech