### PR TITLE
Fix: remove BoardMenu from post detail page

### DIFF
--- a/src/components/Community/BoardMenu.tsx
+++ b/src/components/Community/BoardMenu.tsx
@@ -39,7 +39,7 @@ const Menu = styled.div`
     left: 0;
     top: 0;
     width: auto;
-    padding-bottom: 19px;
+    padding: 18px 0 19px 0;
 
     &::after {
       content: ' ';

--- a/src/pages/community/boards/[boardId].tsx
+++ b/src/pages/community/boards/[boardId].tsx
@@ -36,7 +36,7 @@ export default function Posts() {
 
   if (boardId)
     return (
-      <Board selectedBoardId={Number(boardId)}>
+      <Board selectedBoardId={Number(boardId)} showBoardMenu={true}>
         <BoardHeader />
         <PostList posts={posts} fetch={fetchPosts} />
         <MobileNavigationBar />

--- a/src/pages/community/boards/[boardId]/posts/[postId].tsx
+++ b/src/pages/community/boards/[boardId]/posts/[postId].tsx
@@ -148,7 +148,7 @@ export default function Post() {
           title={Number(boardId) === 1 ? "학식게시판" : "외식게시판"}
           handleBack={router.back}
         />
-        <Board selectedBoardId={Number(boardId) ?? 1}>
+        <Board selectedBoardId={Number(boardId) ?? 1} showBoardMenu={false}>
           <Container>
             <Header>
               <WriterInfoContainer>
@@ -217,7 +217,7 @@ export default function Post() {
           title={Number(boardId) === 1 ? "학식게시판" : "외식게시판"}
           handleBack={router.back}
         />
-        <Board selectedBoardId={Number(boardId) ?? 1}>
+        <Board selectedBoardId={Number(boardId) ?? 1} showBoardMenu={false}>
           <Container>{isError ? "포스트를 찾을 수 없어요" : ""}</Container>
         </Board>
       </>

--- a/src/pages/community/boards/index.tsx
+++ b/src/pages/community/boards/index.tsx
@@ -10,10 +10,11 @@ import { getBoardList } from "utils/api/community";
 
 interface BoardProps {
   selectedBoardId?: number;
+  showBoardMenu: boolean;
   children?: JSX.Element | JSX.Element[];
 }
 
-export default function Board({ selectedBoardId, children }: BoardProps) {
+export default function Board({ selectedBoardId, showBoardMenu, children }: BoardProps) {
   const [boardId, setBoardId] = useState(1);
   const [boards, setBoards] = useState<BoardType[]>([]);
 
@@ -31,7 +32,9 @@ export default function Board({ selectedBoardId, children }: BoardProps) {
   return (
     <Layout>
       <>
-        <BoardMenu boardId={selectedBoardId ?? boardId} setBoardId={setBoardId} boards={boards} />
+        {showBoardMenu && (
+          <BoardMenu boardId={selectedBoardId ?? boardId} setBoardId={setBoardId} boards={boards} />
+        )}
         {children}
       </>
     </Layout>

--- a/src/pages/community/layout.tsx
+++ b/src/pages/community/layout.tsx
@@ -19,7 +19,7 @@ const Content = styled.div`
   height: 100%;
   background: white;
   border-radius: 10px;
-  padding: 20px 19px 0 19px;
+  padding: 0 20px;
   box-sizing: border-box;
 
   @media (max-width: 768px) {


### PR DESCRIPTION
### Summary

게시글 상세 페이지에서 `BoardMenu` component(게시판 네비게이션)를 없앴습니다.

### Tech