### PR TITLE
fix/no-duplicated-request

### DIFF
--- a/src/components/general/InfiniteScrollable.tsx
+++ b/src/components/general/InfiniteScrollable.tsx
@@ -22,7 +22,6 @@ export default function InfiniteScrollable({
 
   const observerCallback = useCallback(
     (entries: IntersectionObserverEntry[]) => {
-      console.log("observed!");
       if (entries[0].isIntersecting && hasNext) {
         setPage((prevPage) => prevPage + 1);
       }


### PR DESCRIPTION
### Summary

postList에서 새로고침 시 observerRef가 관측되기 때문에 page 1과 page 2가 한번에 불러와졌습니다. page 2의 결과값을 page 1보다 먼저 받게 된 경우, page 순서가 바뀌어서 postList가 보여지게 됩니다. 이 이슈를 hasNext를 초기화함으로써 막았습니다.

### Tech
