### PR TITLE
fix: mobile board MenuItem scroll

### DIFF
--- a/src/components/Community/BoardMenu.tsx
+++ b/src/components/Community/BoardMenu.tsx
@@ -34,14 +34,13 @@ const MenuContainer = styled.div`
     align-self: center;
     width: calc(100% + 25px);
     border-bottom: 1px solid #f0f0f0;
-
-    }
   }
 `;
 const MenuInnerContainer = styled.div`
   @media (max-width: 768px) {
     padding: 0 12.5px 0 12.5px;
-    width: 350px;
+    width: 100%;
+    box-sizing: border-box;
   }
 `;
 const Menu = styled.div`


### PR DESCRIPTION
### Summary

모바일 뷰에서 게시판 목록이 가로 스크롤 되지 않는 문제를 해결하였습니다.

### Tech

css 가상 요소 after을 지우고 div 두 개를 추가해서 해결하였으나 after을 사용하면 낭비없이 좀 더 깔끔하게 할 수 있지 않았을까 합니다.