### PR TITLE
fix: fix nickname loading logic in account page

### DIFF
--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -11,8 +11,6 @@ import useIsExceptEmpty from "hooks/UseIsExceptEmpty";
 export default function Account() {
   const router = useRouter();
 
-  const state = useStateContext();
-
   const { userInfo } = UseProfile();
   const { isExceptEmpty, toggleIsExceptEmpty } = useIsExceptEmpty();
 
@@ -21,7 +19,7 @@ export default function Account() {
   useEffect(authGuard, [authStatus]);
 
   const profileURL = userInfo?.image ?? "/img/default-profile.svg";
-  const nickname = userInfo?.nickname ?? `ID ${userInfo?.id}`;
+  const nickname = userInfo?.nickname;
 
   return (
     <AccountLayout>
@@ -33,9 +31,7 @@ export default function Account() {
           }}
         >
           <Profile src={profileURL} alt="프로필 이미지" />
-          <ProfileText>
-            {authStatus === "loading" ? "잠시만 기다려주세요..." : nickname}
-          </ProfileText>
+          <ProfileText>{userInfo ? nickname : "잠시만 기다려주세요..."}</ProfileText>
           <ArrowButton src="/img/right-arrow-grey.svg" alt="오른쪽 화살표" />
         </ContentDiv>
       </ListGroup>


### PR DESCRIPTION
### Summary

설정페이지에서 새로고침시 잠시동안 id undefined가 뜨는 문제를 수정했습니다.

### Tech

- 기존 코드는 useAuth(accessToken)값을 가져와 로딩중 상태를 확인했습니다.
- 하지만 실제 프로필이 불러와지는 순간은 accessToken이 useAuth hook에 로딩된 다음 useProfile 훅에서 데이터 로딩이 완료되는 때가 됩니다. 따라서 useAuth로딩이 완료된 다음 useProfile로딩이 완료되는 전까지의 상황에서 ID undefined문제가 발생했습니다.
- 따라서 로그인 검증을 useAuth가 아닌 useProfile의 userInfo를 활용하도록 하여 문제를 해결했습니다.
- 추가로 더이상 닉네임이 없는 유저는 존재하지 않기 때문에 닉네임이 없을시 시 id를 가져오도록 하는 부분은 제거했습니다.