### PR TITLE
Fix: sanitize css selector for MenuCard

### DIFF
--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -4,7 +4,7 @@ import Menu from "components/Menu";
 import { useDispatchContext } from "context/ContextProvider";
 import useFavorite from "hooks/UseFavorite";
 import { LoadingAnimation } from "styles/globalstyle";
-import { sanitizeForCssSelector } from "utils/FormatUtil";
+import { sanitizeCssSelector } from "utils/FormatUtil";
 
 export default function MenuCard({ data }) {
   const { setInfoData, toggleShowInfo } = useDispatchContext();
@@ -13,7 +13,7 @@ export default function MenuCard({ data }) {
 
   return (
     <>
-      <DesktopContainer className={"a" + sanitizeForCssSelector(data.code)}>
+      <DesktopContainer className={"a" + sanitizeCssSelector(data.code)}>
         <RestInfo>
           <HeaderContainer>
             <Name>{data.name_kr}</Name>
@@ -50,7 +50,7 @@ export default function MenuCard({ data }) {
           </Menus>
         </MenuInfo>
       </DesktopContainer>
-      <MobileContainer className={"a" + sanitizeForCssSelector(data.code)}>
+      <MobileContainer className={"a" + sanitizeCssSelector(data.code)}>
         <RestInfo>
           <HeaderContainer>
             <Name>{data.name_kr}</Name>

--- a/src/components/RestaurantList.tsx
+++ b/src/components/RestaurantList.tsx
@@ -3,10 +3,10 @@ import { useStateContext } from "context/ContextProvider";
 import { useEffect, useState } from "react";
 import useFavorite from "hooks/UseFavorite";
 import useFestival from "hooks/useFestival";
-import { sanitizeForCssSelector } from "utils/FormatUtil";
+import { sanitizeCssSelector } from "utils/FormatUtil";
 
 function scrollRestaurant(restaurant) {
-  let element = document.querySelector(".a" + sanitizeForCssSelector(restaurant));
+  let element = document.querySelector(".a" + sanitizeCssSelector(restaurant));
   if (!element) {
     throw new Error("Cannot find element");
   }

--- a/src/utils/FormatUtil.ts
+++ b/src/utils/FormatUtil.ts
@@ -57,7 +57,7 @@ export function formatPrice(price) {
   return price.toString().slice(0, price.toString().length - 3) + "," + price.toString().slice(-3);
 }
 
-export function sanitizeForCssSelector(str) {
+export function sanitizeCssSelector(str) {
   return str
   .trim()
   .replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9-_:.]/g, '_');


### PR DESCRIPTION
### Summary

`MenuCard` component들의 css class명을 sanitize하기 위한 `sanitizeForCssSelector` 함수를 추가했습니다.

### Tech
 
css selector 규칙에 맞도록 숫자, 영문, 한글, 일부 특수문자(`-`, `_`, `:`, `.`)를 제외한 문자들을 모두 `_`로 치환시키고, 이후 숫자로 시작하는 경우엔 `_`를 앞에 추가했습니다.