### PR TITLE
Fix: fix formatPrice function

### DIFF
--- a/src/utils/FormatUtil.ts
+++ b/src/utils/FormatUtil.ts
@@ -54,6 +54,8 @@ export function getPrevMonth(date) {
 }
 
 export function formatPrice(price) {
+  if(price.toString().length <= 3)
+    return price;
   return price.toString().slice(0, price.toString().length - 3) + "," + price.toString().slice(-3);
 }
 


### PR DESCRIPTION
### Summary

가격이 3자리 이하일 때 앞에 ,(쉼표)가 붙는 문제를 해결했습니다.

### Tech

`Menu` 에서 가격 formatting을 담당하는 `formatPrice` 함수에서, 3자리 이하인 경우 쉼표를 붙이지 않도록 수정했습니다.