### PR TITLE
fix: fix kanji collision

### DIFF
--- a/src/styles/globalstyle.tsx
+++ b/src/styles/globalstyle.tsx
@@ -7,14 +7,16 @@ export const GlobalStyle = createGlobalStyle`
     font-family: 'NIXGONFONTS V2.0';
     src: url('/font/NIXGONFONTS L 2.0.ttf') format('truetype'),
     url('/font/NIXGONFONTS L 2.0.otf') format('opentype');
-    
+    unicode-range: U+0020-007E, U+AC00-D7A3;
+
     font-weight: 400;
   }
   @font-face {
     font-family: 'NanumSquare';
     src: url('/font/NanumSquareExtraBold.ttf') format('truetype'),
     url('/font/NanumSquareOTFExtraBold.otf') format('opentype');
-
+    unicode-range: U+0020-007E, U+AC00-D7A3;
+    
     font-weight: 1000;
   }
 
@@ -22,6 +24,7 @@ export const GlobalStyle = createGlobalStyle`
     font-family: 'NanumSquare';
     src: url('/font/NanumSquareBold.ttf') format('truetype'),
     url('/font/NanumSquareOTFBold.otf') format('opentype');
+    unicode-range: U+0020-007E, U+AC00-D7A3;
 
     font-weight: 700;
   }
@@ -30,6 +33,7 @@ export const GlobalStyle = createGlobalStyle`
     font-family: 'NanumSquare';
     src: url('/font/NanumSquareRegular.ttf') format('truetype'),
     url('/font/NanumSquareOTFRegular.otf') format('opentype');
+    unicode-range: U+0020-007E, U+AC00-D7A3;
 
     font-weight: 400;
   }
@@ -38,6 +42,7 @@ export const GlobalStyle = createGlobalStyle`
     font-family: 'NanumSquare';
     src: url('/font/NanumSquareLight.ttf') format('truetype'),
     url('/font/NanumSquareOTFLight.otf') format('opentype');
+    unicode-range: U+0020-007E, U+AC00-D7A3;
 
     font-weight: 100;
   }


### PR DESCRIPTION
### Summary

한자 폰트깨짐을 방지하기 위한 pr입니다.

### Tech

나눔스퀘어 폰트를 한글, 영숫자에만 적용되도록 수정했습니다.