### PR TITLE
Home layout(LeftSide, RightSide) 수정

### DIFF
--- a/src/app/components/LeftSide.tsx
+++ b/src/app/components/LeftSide.tsx
@@ -21,8 +21,6 @@ const Container = styled(TwoColumnLayout.Left)`
   display: flex;
   flex-direction: column;
   gap: 14px;
-  margin-left: 50px;
-  margin-right: 18px;
   height: fit-content;
   box-sizing: border-box;
   width: 378px;

--- a/src/app/components/RightSide.tsx
+++ b/src/app/components/RightSide.tsx
@@ -17,7 +17,6 @@ const Container = styled(TwoColumnLayout.Right)`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  margin-left: 18px;
   box-sizing: border-box;
   max-width: 818px;
   height: 100%;


### PR DESCRIPTION
### Summary

`<LeftSide>`, `<RightSide>` component의 디자인을 수정하여 figma의 디자인에 맞췄습니다.

### Tech

figma의 디자인과 달리 home의 `<LeftSide>`, `<RightSide>` component에 좌우 margin이 들어가 있어 이를 제거했습니다.