### PR TITLE
fix: remove unnecessary swcMinify option

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   output: process.env.NEXT_OUTPUT_MODE === "export" ? "export" : "standalone",
-  swcMinify: true,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
### Summary

`next.config.js` 파일에서 `swcMinify` 옵션을 제거하여 아래의 warning을 없앴습니다.
```
 ⚠ Invalid next.config.js options detected: 
 ⚠ Unrecognized key(s) in object: 'swcMinify'
```

### Tech

nextjs 12부터 SWC를 이용한 minification이 기본적으로 활성화됨에 따라, nextjs 버전 15부터는 `swcMinify` 옵션이 아예 제거되었습니다. ([참고](https://github.com/vercel/next.js/pull/65579)) 이에 따라 `swcMinify` 옵션이 존재하면 Unrecognized key(s) warning이 발생하게 되어, 이를 제거함으로써 warning을 제거했습니다.