### PR TITLE
fix: redirect to home after kakao login

### DIFF
--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -22,7 +22,7 @@ export default function Auth() {
     loginKakao(code)
       .then((accessToken) => {
         login(accessToken);
-        router.back();
+        router.push("/");
       })
       .catch(onHttpError);
   }, []);


### PR DESCRIPTION
### Summary

카카오 로그인 redirect 관련 버그 수정

### Tech

카카오 로그인 후 `router.back()` 에 의해 이전 페이지로 넘어가도록 되어있었는데, 이로 인해 로그인 페이지로 계속 돌아오는 버그가 있었습니다. `router.push('/')`로 변경함으로써 홈으로 가도록 수정했습니다.