### PR TITLE
Remove festival toggle

### DIFF
--- a/src/app/components/RightSide.tsx
+++ b/src/app/components/RightSide.tsx
@@ -15,7 +15,6 @@ export default function RightSide() {
         alignItems: "center",
       }}>
         <Meal />
-        <FestivalToggle />
       </div>
       <MenuList />
     </Container>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,7 +96,6 @@ export default function Home() {
           alignItems: "center",
         }}>
           <Meal />
-          <FestivalToggle />
         </div>
         <MobileFilterBar />
         <MenuList />

--- a/src/hooks/UseFestival.ts
+++ b/src/hooks/UseFestival.ts
@@ -19,7 +19,7 @@ export default function useFestival() {
       .catch((e) => {
         onHttpError(e);
       });
-    };
+  };
 
   useEffect(() => {
     if (date) {


### PR DESCRIPTION
### Summary

축제 기간이 끝나, 축제 토글을 제거했습니다.

### Tech

가을 축제 때 코드를 재활용하기 위해, 토글 component 코드는 그대로 두고 페이지에서만 제거했습니다.