### PR TITLE
feat: 다크모드 QA 반영 (account 위주)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["next", "next/core-web-vitals", "prettier"],
   "rules": {
-    "indent": ["error", 2]
+    "indent": "off"
   }
 }

--- a/src/app/account/inquiry/page.tsx
+++ b/src/app/account/inquiry/page.tsx
@@ -51,7 +51,11 @@ export default function Inquiry() {
 
   return (
     <>
-      <MobileSubHeader title="1:1 문의하기" handleBack={() => router.push("/account")} />
+      <MobileSubHeader
+        title="1:1 문의하기"
+        containerColor="secondary"
+        handleBack={() => router.push("/account")}
+      />
       <Container>
         <Title>1:1 문의하기</Title>
         <MobileBox>
@@ -68,7 +72,7 @@ export default function Inquiry() {
         </InquireBox>
         <ButtonBox>
           <ButtonCancel onClick={handleCancel}>취소</ButtonCancel>
-          <ButtonConfirm onClick={handlePost}>전송하기</ButtonConfirm>
+          <ButtonConfirm onClick={handlePost}>완료</ButtonConfirm>
         </ButtonBox>
       </Container>
     </>
@@ -77,8 +81,7 @@ export default function Inquiry() {
 
 const Container = styled.div`
   width: 701px;
-  background-color: var(--SemanticColor-Background-Primary);
-  border: 1px solid #e8e8e8;
+  background-color: var(--SemanticColor-Background-Secondary);
   border-radius: 8px;
 
   @media (max-width: 768px) {
@@ -93,7 +96,7 @@ const Title = styled.div`
   margin: 24.04px 0 0 23.5px;
   font-size: 20px;
   font-weight: 700;
-  color: var(--Color-Foundation-orange-500);
+  color: var(--Color-Foundation-gray-900);
 
   @media (max-width: 768px) {
     display: none;
@@ -166,7 +169,7 @@ const TextArea = styled.textarea`
   height: 100%;
   padding: 15.73px 16px;
   box-sizing: border-box;
-  background-color: var(--Color-Foundation-gray-50);
+  background-color: var(--SemanticColor-Background-Tertiary);
   border: 0;
   border-radius: 8px;
   resize: none;
@@ -183,7 +186,7 @@ const WordCnt = styled.div`
   font-size: 11px;
   font-weight: 400;
   line-height: 12.48px;
-  color: #707070;
+  color: var(--Color-Foundation-gray-700);
 
   @media (max-width: 768px) {
     position: absolute;
@@ -217,8 +220,8 @@ const Button = styled.div`
 `;
 
 const ButtonCancel = styled(Button)`
-  background-color: #eeeeee;
-  color: #8e8e8e;
+  background-color: var(--SemanticColor-Background-Tertiary);
+  color: var(--Color-Foundation-gray-600);
 
   @media (max-width: 768px) {
     display: none;

--- a/src/app/account/inquiry/page.tsx
+++ b/src/app/account/inquiry/page.tsx
@@ -67,7 +67,7 @@ export default function Inquiry() {
           <Nickname>{userInfo?.nickname ?? `ID ${userInfo?.id}`}</Nickname>
         </UserBox>
         <InquireBox>
-          <TextArea value={voc} onChange={handleTextAreaChange} />
+          <TextArea value={voc} onChange={handleTextAreaChange} placeholder="내용을 입력해주세요" />
           <WordCnt>{`${voc.length} 자 / 500 자`}</WordCnt>
         </InquireBox>
         <ButtonBox>
@@ -157,6 +157,9 @@ const InquireBox = styled.div`
   width: 658px;
   height: 378.11px;
 
+  display: inline-grid;
+  grid-template-areas: "stack";
+
   @media (max-width: 768px) {
     width: calc(100% - 56px);
     margin-left: 28px;
@@ -165,6 +168,7 @@ const InquireBox = styled.div`
   }
 `;
 const TextArea = styled.textarea`
+  grid-area: stack;
   width: 100%;
   height: 100%;
   padding: 15.73px 16px;
@@ -173,26 +177,26 @@ const TextArea = styled.textarea`
   border: 0;
   border-radius: 8px;
   resize: none;
+  &::placeholder {
+    color: var(--SemanticColor-Text-Bubble);
+  }
 
   &:focus {
     outline: none;
   }
 `;
 const WordCnt = styled.div`
-  width: 650px;
-  margin-top: -26.46px;
-  padding-right: 35.95px;
+  grid-area: stack;
+  align-self: end;
+  justify-self: end;
+  /* width: 650px; */
+  margin-right: 8px;
+  margin-bottom: 16px;
   text-align: right;
   font-size: 11px;
   font-weight: 400;
   line-height: 12.48px;
   color: var(--Color-Foundation-gray-700);
-
-  @media (max-width: 768px) {
-    position: absolute;
-    right: 0;
-    padding-right: 35px;
-  }
 `;
 const ButtonBox = styled.div`
   display: flex;

--- a/src/app/account/inquiry/page.tsx
+++ b/src/app/account/inquiry/page.tsx
@@ -123,8 +123,10 @@ const Description = styled.p`
   text-align: center;
   margin: 0;
   margin-left: 10px;
-  font-size: 20px;
-  font-weight: 700;
+  color: var(--Color-Foundation-base-black);
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 140%;
 `;
 
 const UserBox = styled.div`

--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -1,17 +1,31 @@
-"use client"
+"use client";
 
+import { useSelectedLayoutSegments } from "next/navigation";
 import styled from "styled-components";
 import OneColumnLayout from "styles/layouts/OneColumnLayout";
+import { BackgroundColor } from "styles/styled";
 
 export default function AccountLayout({ children }) {
+  const segments = useSelectedLayoutSegments();
+  const sub = segments[0] ?? "";
+  const colorMap: Record<string, BackgroundColor> = {
+    profile: "secondary",
+    mypost: "secondary",
+    inquiry: "secondary",
+    restaurant: "secondary",
+  };
+  const containerColor = colorMap[sub];
+
   return (
-    <Container>
+    <Container color={containerColor}>
       <Content>{children}</Content>
     </Container>
   );
 }
-const Container = styled(OneColumnLayout.Container)`
+const Container = styled(OneColumnLayout.Container)<{ color?: string }>`
   @media (max-width: 768px) {
+    background-color: ${({ color }) =>
+      color === "secondary" ? "var(--SemanticColor-Background-Secondary)" : ""};
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -30,6 +30,7 @@ const Container = styled(OneColumnLayout.Container)<{ color?: string }>`
     display: flex;
     flex-direction: column;
     height: 100%;
+    padding: 0;
   }
 `;
 const Content = styled.div`

--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -13,6 +13,7 @@ export default function AccountLayout({ children }) {
     mypost: "secondary",
     inquiry: "secondary",
     restaurant: "secondary",
+    user: "secondary",
   };
   const containerColor = colorMap[sub];
 

--- a/src/app/account/mypost/page.tsx
+++ b/src/app/account/mypost/page.tsx
@@ -51,10 +51,9 @@ export default function MyPost() {
 const Container = styled.div`
   padding: 0 18.5px;
   width: 701px;
-  background: var(--SemanticColor-Background-Primary);
-  border: 1px solid var(--Color-Foundation-gray-200);
   border-radius: 8px;
   box-sizing: border-box;
+  background-color: var(--SemanticColor-Background-Secondary);
 
   @media (max-width: 768px) {
     width: 100%;
@@ -65,7 +64,7 @@ const Container = styled.div`
 
 const Header = styled.div`
   margin: 24.08px 0 29.42px 4.5px;
-  color: var(--Color-Foundation-orange-500);
+  color: var(--Color-Foundation-gray-900);
   font-size: 20px;
   font-weight: 700;
   line-height: 23px;
@@ -92,5 +91,5 @@ const BreakLine = styled.hr`
   margin-bottom: 29.4px;
   border: 0;
   height: 1px;
-  background: var(--Color-Foundation-gray-100);
+  background: var(--Color-Foundation-gray-500);
 `;

--- a/src/app/account/mypost/page.tsx
+++ b/src/app/account/mypost/page.tsx
@@ -42,7 +42,6 @@ export default function MyPost() {
         <Container>
           <Header>내가 쓴 글</Header>
           <PostList posts={posts} fetch={fetchMyPosts} />
-          {posts.length >= 1 ? <BreakLine /> : null}
         </Container>
       </>
     );
@@ -56,9 +55,10 @@ const Container = styled.div`
   background-color: var(--SemanticColor-Background-Secondary);
 
   @media (max-width: 768px) {
+    padding-top: 16px;
     width: 100%;
     margin-top: -4px;
-    border: 0;
+    border: none;
   }
 `;
 
@@ -91,5 +91,5 @@ const BreakLine = styled.hr`
   margin-bottom: 29.4px;
   border: 0;
   height: 1px;
-  background: var(--Color-Foundation-gray-500);
+  background: var(--Color-Foundation-gray-100);
 `;

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -27,7 +27,7 @@ export default function Account() {
   const nickname = userInfo?.nickname;
 
   return (
-    <>
+    <Container>
       <ListGroup>
         <ContentDiv
           onClick={() => {
@@ -97,7 +97,7 @@ export default function Account() {
         </ContentDiv>
       </ListGroup>
       <MobileNavigationBar />
-    </>
+    </Container>
   );
 }
 
@@ -118,6 +118,12 @@ const ArrowButtonWrapper = styled.div`
 
   @media (max-width: 768px) {
     margin-right: 13.75px;
+  }
+`;
+
+const Container = styled.div`
+  @media (max-width: 768px) {
+    padding-top: 24px;
   }
 `;
 

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -146,7 +146,6 @@ const ListGroup = styled.div<{ isLast?: boolean }>`
   background-color: var(--SemanticColor-Background-Secondary);
   width: 544px;
   margin-bottom: ${(props) => (props.isLast ? "0" : "19px")};
-  border: 1px solid var(--SemanticColor-Border-Primary);
   border-radius: 8px;
 
   @media (max-width: 768px) {

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -153,6 +153,7 @@ const ListGroup = styled.div<{ isLast?: boolean }>`
   width: 544px;
   margin-bottom: ${(props) => (props.isLast ? "0" : "19px")};
   border-radius: 8px;
+  border: 1px solid var(--Color-Foundation-gray-200, #E5E6E9);
 
   @media (max-width: 768px) {
     width: calc(100dvw - 40px);

--- a/src/app/account/profile/page.tsx
+++ b/src/app/account/profile/page.tsx
@@ -76,7 +76,7 @@ export default function SettingProfile() {
     <>
       <MobileSubHeader title="프로필 관리" handleBack={() => router.push("/account")} />
       <Container>
-        <Title>닉네임 설정</Title>
+        <Title>프로필 관리</Title>
         <ProfileEdit
           nickname={nickname}
           setNickname={setNickname}
@@ -104,7 +104,7 @@ export default function SettingProfile() {
 
 const Container = styled.div`
   width: 533px;
-  background-color: var(--Color-Foundation-base-white);
+  background-color: var(--SemanticColor-Background-Secondary);
   border: 1px solid var(--Color-Foundation-gray-200);
   border-radius: 8px;
 
@@ -122,7 +122,7 @@ const Title = styled.div`
   margin: 24px 0 0 22.48px;
   font-size: 20px;
   font-weight: 700;
-  color: var(--Color-Foundation-orange-500);
+  color: var(--Color-Foundation-gray-900);
 
   @media (max-width: 768px) {
     display: none;
@@ -134,6 +134,7 @@ const ButtonGroup = styled.div`
   justify-content: space-between;
   width: calc(100% - 39px);
   margin: 0 19.5px 18px 19.5px;
+  background-color: transparent;
 
   @media (max-width: 768px) {
     margin-bottom: 32.06px;

--- a/src/app/account/user/page.tsx
+++ b/src/app/account/user/page.tsx
@@ -46,7 +46,11 @@ export default function UserSetting() {
 
   return (
     <>
-      <MobileSubHeader title="계정관리" handleBack={() => router.push("/account")} />
+      <MobileSubHeader
+        title="계정관리"
+        handleBack={() => router.push("/account")}
+        containerColor="primary"
+      />
       <Container>
         <Title>계정 관리</Title>
         <ContentDiv onClick={handleLogout}>
@@ -78,7 +82,7 @@ const Title = styled.div`
   margin: 24.57px 0 0 22.45px;
   font-size: 20px;
   font-weight: 700;
-  color: var(--Color-Foundation-orange-500);
+  color: var(--Color-Foundation-gray-900);
   margin-bottom: 30.43px;
 
   @media (max-width: 768px) {

--- a/src/app/account/user/page.tsx
+++ b/src/app/account/user/page.tsx
@@ -74,6 +74,7 @@ const Container = styled.div`
   border-radius: 8px;
 
   @media (max-width: 768px) {
+    margin-top: 24px;
     width: calc(100dvw - 40px);
   }
 `;

--- a/src/app/community/boards/[boardId]/components/Post.tsx
+++ b/src/app/community/boards/[boardId]/components/Post.tsx
@@ -31,8 +31,8 @@ export function Post({ post }: PropsPost) {
         <PhotoZone>
           {images
             ? images.map((src, idx) =>
-              idx < 1 ? <Photo key={src} src={src} alt="게시글 사진 모음" /> : null,
-            )
+                idx < 1 ? <Photo key={src} src={src} alt="게시글 사진 모음" /> : null,
+              )
             : null}
         </PhotoZone>
       </Container>
@@ -61,12 +61,12 @@ const Container = styled.div`
     height: 1px;
     top: 0;
     left: 50%;
-    background-color: var(--SemanticColor-Border-Primary);
+    background-color: var(--Color-Foundation-gray-500);
     transform: translateX(-50%);
 
     @media (max-width: 768px) {
       width: calc(100% + 25px);
-      background-color: var(--SemanticColor-Border-Primary);
+      background-color: var(--Color-Foundation-gray-500);
     }
   }
 `;
@@ -82,11 +82,11 @@ const Info = styled.div<{ isImages: boolean | null }>`
     gap: 9px;
     height: min-content;
 
-  ${(props) =>
-    props.isImages !== null &&
-    css`
-      max-width: calc(100% - 71.5px);
-    `}
+    ${(props) =>
+      props.isImages !== null &&
+      css`
+        max-width: calc(100% - 71.5px);
+      `}
   }
 `;
 

--- a/src/app/community/boards/[boardId]/components/Post.tsx
+++ b/src/app/community/boards/[boardId]/components/Post.tsx
@@ -2,18 +2,23 @@ import styled, { css } from "styled-components";
 import { Post as PostType } from "types";
 import Link from "next/link";
 import { LoadingAnimation } from "styles/globalstyle";
+import { useTheme } from "next-themes";
+import UseCurrentTheme from "hooks/UseCurrentTheme";
 
 interface PropsPost {
   post: PostType;
+  isFirst?: boolean;
 }
 
-export function Post({ post }: PropsPost) {
+export function Post({ post, isFirst = false }: PropsPost) {
   const { boardId, id, title, content, isLiked, likeCount, commentCount, images } = post;
   const isLikedImg = isLiked ? "/img/post-like-fill.svg" : "/img/post-like.svg";
+  const { currentTheme } = UseCurrentTheme();
+  const isDark = currentTheme === "dark";
 
   return (
     <Link href={`/community/boards/${boardId}/posts/${id}`}>
-      <Container>
+      <Container $isFirst={isFirst} $isDark={isDark}>
         <Info isImages={images && images.length > 0}>
           <Title>{title}</Title>
           <ContentPreview>{content}</ContentPreview>
@@ -40,7 +45,7 @@ export function Post({ post }: PropsPost) {
   );
 }
 
-const Container = styled.div`
+const Container = styled.div<{ $isFirst: boolean; $isDark: boolean }>`
   ${LoadingAnimation}
   display: flex;
   position: relative;
@@ -66,7 +71,15 @@ const Container = styled.div`
     @media (max-width: 768px) {
       /* display: none; */
       width: calc(100% + 25px);
-      background-color: var(--Color-Foundation-gray-100);
+      ${(props) =>
+        !props.$isDark
+          ? css`
+              background-color: var(--Color-Foundation-gray-100);
+            `
+          : props.$isFirst &&
+            css`
+              background-color: var(--Color-Foundation-gray-100);
+            `}
     }
   }
 `;

--- a/src/app/community/boards/[boardId]/components/Post.tsx
+++ b/src/app/community/boards/[boardId]/components/Post.tsx
@@ -61,12 +61,12 @@ const Container = styled.div`
     height: 1px;
     top: 0;
     left: 50%;
-    background-color: var(--Color-Foundation-gray-500);
+    background-color: var(--SemanticColor-Border-Secondary);
     transform: translateX(-50%);
-
     @media (max-width: 768px) {
+      /* display: none; */
       width: calc(100% + 25px);
-      background-color: var(--Color-Foundation-gray-500);
+      background-color: var(--Color-Foundation-gray-100);
     }
   }
 `;

--- a/src/app/community/boards/[boardId]/components/PostList.tsx
+++ b/src/app/community/boards/[boardId]/components/PostList.tsx
@@ -25,7 +25,7 @@ export function PostList({ posts, fetch }: PropsPostList) {
         // available(신고 많이 받으면 false)한 경우만 보여지게 합니다.
         posts
           .filter((post) => post.available === true)
-          .map((post, i) => <Post key={i} post={post} />)
+          .map((post, i) => <Post key={i} post={post} isFirst={i === 0} />)
       ) : (
         <>
           {isLoading ? (

--- a/src/components/Account/ProfileEdit.tsx
+++ b/src/components/Account/ProfileEdit.tsx
@@ -65,8 +65,8 @@ export default function ProfileEdit(props: ProfileEditProps) {
             changeToDefaultImage
               ? defaultProfileURL
               : imageBlob
-                ? URL.createObjectURL(imageBlob)
-                : userInfo?.image ?? defaultProfileURL
+              ? URL.createObjectURL(imageBlob)
+              : userInfo?.image ?? defaultProfileURL
           }
           alt="프로필 사진"
         />
@@ -166,7 +166,7 @@ const InputBox = styled.label`
   justify-content: space-between;
   align-items: center;
   margin: 36.51px 22.48px 36.51px 22.48px;
-  border: 1px solid var(--Color-Foundation-gray-200);
+  border: 1px solid var(--SemanticColor-Border-Secondary);
   border-radius: 8px;
   padding-left: 14px;
 

--- a/src/components/Account/RestaurantOrderEditor.tsx
+++ b/src/components/Account/RestaurantOrderEditor.tsx
@@ -115,8 +115,8 @@ const DragZone = styled.div`
   }
 `;
 const DragContainer = styled.div<{ dragging: boolean }>`
-  &:hover {
-    background-color: var(--Color-Foundation-gray-100);
+  &:focus {
+    background-color: transparent;
   }
 `;
 
@@ -142,6 +142,12 @@ const Restaurant = styled.p`
   font-weight: 400;
   font-size: 16px;
   line-height: 23px;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  min-width: 0;
 
   @media (max-width: 768px) {
     font-size: 15px;

--- a/src/components/Account/RestaurantOrderEditor.tsx
+++ b/src/components/Account/RestaurantOrderEditor.tsx
@@ -103,7 +103,7 @@ const Description = styled.p`
     width: 100%;
     height: 50px;
     margin: 0;
-    /* background-color: var(--Color-Foundation-base-white); */
+    background-color: var(--Color-Background-main);
     z-index: 1;
   }
 `;

--- a/src/components/Account/RestaurantOrderEditor.tsx
+++ b/src/components/Account/RestaurantOrderEditor.tsx
@@ -103,7 +103,7 @@ const Description = styled.p`
     width: 100%;
     height: 50px;
     margin: 0;
-    background-color: var(--Color-Foundation-base-white);
+    /* background-color: var(--Color-Foundation-base-white); */
     z-index: 1;
   }
 `;

--- a/src/components/Account/RestaurantOrderEditor.tsx
+++ b/src/components/Account/RestaurantOrderEditor.tsx
@@ -37,7 +37,7 @@ export default function RestzaurantOrderEditor({ order, reorder }: RestaurantOrd
                       {...provided.dragHandleProps}
                       dragging={snapshot.isDragging}
                     >
-                      <DragBox>
+                      <DragBox dragging={snapshot.isDragging}>
                         <Restaurant>{nameKr}</Restaurant>
                         <DragButton dragging={snapshot.isDragging}>
                           <Line />
@@ -63,7 +63,7 @@ const Container = styled.div`
   padding-bottom: 12.68px;
   border: 1px solid var(--Color-Foundation-gray-200);
   border-radius: 8px;
-  background-color: var(--Color-Foundation-base-white);
+  background-color: var(--SemanticColor-Background-Secondary);
 
   @media (max-width: 768px) {
     width: 100%;
@@ -79,7 +79,7 @@ const Title = styled.h2`
   font-weight: 700;
   font-size: 20px;
   line-height: 23px;
-  color: var(--Color-Foundation-orange-500);
+  color: var(--Color-Foundation-gray-900);
 
   @media (max-width: 768px) {
     display: none;
@@ -120,7 +120,7 @@ const DragContainer = styled.div<{ dragging: boolean }>`
   }
 `;
 
-const DragBox = styled.div`
+const DragBox = styled.div<{ dragging: boolean }>`
   display: flex;
   justify-content: space-between;
   width: 499.04px;
@@ -128,11 +128,12 @@ const DragBox = styled.div`
   border: 1px solid var(--Color-Foundation-gray-200);
   border-radius: 8px;
   margin: 7.92px 22.15px;
+  background-color: ${(props) =>
+    props.dragging ? "var(--Color-Foundation-gray-50)" : "var(--SemanticColor-Element-Tooltip2)"};
 
   @media (max-width: 768px) {
     width: calc(100% - 40px);
     margin: 7.92px 0px 0px 20px;
-    background-color: var(--Color-Foundation-base-white);
   }
 `;
 
@@ -163,6 +164,6 @@ const DragButton = styled.div<{ dragging: boolean }>`
 const Line = styled.div`
   width: 19px;
   height: 0px;
-  border: 1px solid var(--Color-Foundation-base-white);
+  border: 1px solid var(--Color-Static-White);
   margin: 2.08px 0;
 `;

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -110,7 +110,7 @@ const MainContainer = styled.div`
   width: 497px;
   height: 565px;
   transform: translate(-50%, -50%);
-  background: var(--Color-Main-Orange);
+  background: var(--Color-Static-Orange);
   border-radius: 13px;
 
   @media (max-width: 768px) {
@@ -143,7 +143,7 @@ const LoginTitle = styled.p`
   font-family: NanumSquare;
   font-weight: 800;
   font-size: 20px;
-  color: var(--Color-Main-White);
+  color: var(--Color-Static-White);
 `;
 
 const CloseButton = styled.img`
@@ -192,8 +192,8 @@ const SocialButton = styled.div<{ provider: "kakao" | "google" | "apple" }>`
   font-family: NanumSquare;
   font-size: 14px;
   background-color: ${(props) =>
-    props.provider === "kakao" ? "#fee500" : "var(--Color-Main-White)"};
-  color: var(--Color-Main-Black);
+    props.provider === "kakao" ? "#fee500" : "var(--Color-Static-White)"};
+  color: var(--Color-Static-Black);
 
   border-radius: 6px;
   position: relative;

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -76,7 +76,11 @@ export default function LoginModal({ onClose }: LoginModalProps) {
               height={41}
               left={10.5}
               right={74}
-              src={isDark ? "/img/modal/login/google-union-dark.png" : "/img/modal/login/google-union.svg"}
+              src={
+                isDark
+                  ? "/img/modal/login/google-union-dark.png"
+                  : "/img/modal/login/google-union.svg"
+              }
               alt="구글 로그인"
             />
             Login with Google
@@ -87,7 +91,7 @@ export default function LoginModal({ onClose }: LoginModalProps) {
               height={18}
               left={16.5}
               right={77}
-              src={isDark ? "/img/modal/login/apple-union-dark.png" : "/img/modal/login/apple-union.svg"}
+              src={"/img/modal/login/apple-union.svg"}
               alt="애플 로그인"
             />
             Login with Apple
@@ -106,7 +110,7 @@ const MainContainer = styled.div`
   width: 497px;
   height: 565px;
   transform: translate(-50%, -50%);
-  background: var(--Color-Foundation-orange-500);
+  background: var(--Color-Main-Orange);
   border-radius: 13px;
 
   @media (max-width: 768px) {
@@ -139,7 +143,7 @@ const LoginTitle = styled.p`
   font-family: NanumSquare;
   font-weight: 800;
   font-size: 20px;
-  color: var(--Color-Foundation-base-white);
+  color: var(--Color-Main-White);
 `;
 
 const CloseButton = styled.img`
@@ -188,9 +192,8 @@ const SocialButton = styled.div<{ provider: "kakao" | "google" | "apple" }>`
   font-family: NanumSquare;
   font-size: 14px;
   background-color: ${(props) =>
-    props.provider === "kakao" ? "#fee500" : "var(--Color-Foundation-base-white)"};
-  color: ${(props) =>
-    props.provider === "kakao" ? "#181600" : "var(--Color-Foundation-gray-900)"};
+    props.provider === "kakao" ? "#fee500" : "var(--Color-Main-White)"};
+  color: var(--Color-Main-Black);
 
   border-radius: 6px;
   position: relative;

--- a/src/components/general/MobileNavigationBar.tsx
+++ b/src/components/general/MobileNavigationBar.tsx
@@ -30,12 +30,12 @@ export default function MobileNavigationBar() {
     isFilterFavorite === true
       ? "favorite"
       : addr === "/" || addr?.startsWith("/menu")
-        ? "menu"
-        : addr?.startsWith("/community")
-          ? "community"
-          : addr?.startsWith("/account")
-            ? "account"
-            : null;
+      ? "menu"
+      : addr?.startsWith("/community")
+      ? "community"
+      : addr?.startsWith("/account")
+      ? "account"
+      : null;
 
   if (!rootElement) return null;
 
@@ -104,7 +104,7 @@ const IconWrapper = styled.div<{ $isActive: boolean }>`
   width: 36px;
   height: 36px;
   color: ${({ $isActive }) =>
-    $isActive ? "var(--Color-Foundation-orange-500)" : "var(--Color-Foundation-gray-500)"};
+    $isActive ? "var(--Color-Foundation-orange-500)" : "var(--SemanticColor-Icon-GrayIcon)"};
 
   display: flex;
   align-items: center;
@@ -124,5 +124,5 @@ const NavName = styled.div<{ $isActive: boolean }>`
   text-align: center;
   vertical-align: middle;
   color: ${({ $isActive }) =>
-    $isActive ? "var(--Color-Foundation-orange-500)" : "var(--Color-Foundation-gray-500)"};
+    $isActive ? "var(--Color-Foundation-orange-500)" : "var(--SemanticColor-Icon-GrayIcon)"};
 `;

--- a/src/components/general/MobileNavigationBar.tsx
+++ b/src/components/general/MobileNavigationBar.tsx
@@ -92,7 +92,7 @@ const Container = styled.div`
   box-sizing: border-box;
   width: 100%;
   height: 83px;
-  background-color: var(--SemanticColor-Background-Primary, #fff);
+  background-color: var(--SemanticColor-Background-Secondary, #fff);
   z-index: 1;
 
   @media (max-width: 768px) {

--- a/src/components/general/MobileSubHeader.tsx
+++ b/src/components/general/MobileSubHeader.tsx
@@ -5,18 +5,20 @@ import { Board as BoardType, RawBoard } from "types";
 import { getBoardList } from "utils/api/community";
 import { boardParser } from "utils/DataUtil";
 import LeftArrowMobileIcon from "assets/icons/left-arrow-mobile.svg";
+import { BackgroundColor } from "styles/styled";
 
 export default function MobileSubHeader({
   title,
   selectedBoardId,
   handleBack,
+  containerColor = "secondary",
 }: {
   title?: string;
   selectedBoardId?: number;
   handleBack: () => void;
+  containerColor?: BackgroundColor;
 }) {
   const [boards, setBoards] = useState<BoardType[]>([]);
-
   useEffect(() => {
     function setParsedBoards(board: RawBoard) {
       setBoards((prev) => [...prev, boardParser(board)]);
@@ -38,7 +40,7 @@ export default function MobileSubHeader({
 
   if (rootElement)
     return createPortal(
-      <MobileHeader>
+      <MobileHeader $containercolor={containerColor}>
         <BackButton onClick={handleBack} aria-label="뒤로 가기" />
         <Title>{title || boardTitle}</Title>
       </MobileHeader>,
@@ -46,12 +48,15 @@ export default function MobileSubHeader({
     );
 }
 
-const MobileHeader = styled.div`
+const MobileHeader = styled.div<{ $containercolor?: BackgroundColor }>`
   display: none;
   font-size: 20px;
   margin: 0;
   top: 0;
-  background: var(--SemanticColor-Background-Secondary);
+  background: ${({ $containercolor }) =>
+    $containercolor === "secondary"
+      ? "var(--SemanticColor-Background-GNB-Secondary)"
+      : "var(--SemanticColor-Background-GNB)"};
   position: absolute;
   width: 100%;
   height: 44px;
@@ -68,7 +73,7 @@ const BackButton = styled(LeftArrowMobileIcon)`
   width: 10px;
   height: 16px;
   left: 16px;
-  color: var(--SemanticColor-Background-Secondary);
+  color: var(--Color-Static-White);
   cursor: pointer;
 `;
 

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -69,7 +69,7 @@
   margin-bottom: 14px;
 }
 .react-calendar__month-view__weekdays__weekday {
-  color: var(--Color-Foundation-base-black);
+  color: var(--Color-Foundation-gray-600);
   font-size: 13px;
   font-weight: 700;
   line-height: 140%; /* 18.2px */
@@ -84,7 +84,7 @@
 }
 
 .react-calendar__month-view__days__day {
-  color: var(--Color-Foundation-gray-700);
+  color: var(--Color-Foundation-gray-900);
   text-align: center;
   font-size: 14px;
   font-weight: var(--Font-weight-bold, 700);
@@ -132,7 +132,7 @@
   }
 }
 .react-calendar__tile--active {
-  color: var(--SemanticColor-Text-Button); 
+  color: var(--SemanticColor-Text-Button);
   line-height: 150%; /* 21px */
   position: relative;
   z-index: 1;
@@ -151,7 +151,7 @@
   }
 
   &.today {
-    color: var(--SemanticColor-Text-Button); 
+    color: var(--SemanticColor-Text-Button);
     &::before {
       background-color: var(--Color-Foundation-orange-500);
     }

--- a/src/styles/globalstyle.tsx
+++ b/src/styles/globalstyle.tsx
@@ -166,6 +166,10 @@ export const GlobalStyle = createGlobalStyle`
     --Color-Foundation-Tint-orange: #FF952240;
 
     --Color-Main-Active: #FFE8CE;
+    --Color-Main-Orange: #FF9522;
+    --Color-Main-White: #FFFFFF;
+    --Color-Main-Black: #000000;
+
 
     --Color-Accent-like: #F86627;
 
@@ -224,6 +228,9 @@ export const GlobalStyle = createGlobalStyle`
     --Color-Foundation-Tint-orange: #F28C1D40;
 
     --Color-Main-Active: #FFEAD3;
+    --Color-Main-Orange: #FF9522;
+    --Color-Main-White: #FFFFFF;
+    --Color-Main-Black: #000000;
 
     --Color-Accent-like: #F86627;
 

--- a/src/styles/globalstyle.tsx
+++ b/src/styles/globalstyle.tsx
@@ -166,10 +166,6 @@ export const GlobalStyle = createGlobalStyle`
     --Color-Foundation-Tint-orange: #FF952240;
 
     --Color-Main-Active: #FFE8CE;
-    --Color-Main-Orange: #FF9522;
-    --Color-Main-White: #FFFFFF;
-    --Color-Main-Black: #000000;
-
 
     --Color-Accent-like: #F86627;
 
@@ -199,6 +195,11 @@ export const GlobalStyle = createGlobalStyle`
     --SemanticColor-Element-Tooltip: var(--Color-Foundation-gray-100);
     --SemanticColor-Element-Tooltip2: var(--Color-Foundation-base-white);
     --SemanticColor-Element-Control: var(--Color-Foundation-gray-200);
+
+    --Color-Static-Orange: #FF9522;
+    --Color-Static-White: #FFFFFF;
+    --Color-Static-Black: #000000;
+
   }
 
   .dark {
@@ -228,9 +229,6 @@ export const GlobalStyle = createGlobalStyle`
     --Color-Foundation-Tint-orange: #F28C1D40;
 
     --Color-Main-Active: #FFEAD3;
-    --Color-Main-Orange: #FF9522;
-    --Color-Main-White: #FFFFFF;
-    --Color-Main-Black: #000000;
 
     --Color-Accent-like: #F86627;
 
@@ -260,6 +258,10 @@ export const GlobalStyle = createGlobalStyle`
     --SemanticColor-Element-Tooltip: var(--Color-Foundation-gray-400);
     --SemanticColor-Element-Tooltip2: var(--Color-Foundation-gray-400);
     --SemanticColor-Element-Control: var(--Color-Foundation-gray-500);
+
+    --Color-Static-Orange: #FF9522;
+    --Color-Static-White: #FFFFFF;
+    --Color-Static-Black: #000000;
   }
 `;
 

--- a/src/styles/layouts/OneColumnLayout.tsx
+++ b/src/styles/layouts/OneColumnLayout.tsx
@@ -12,7 +12,7 @@ const Container = styled.div`
     width: 100%;
     max-width: 100%;
     margin-top: 0;
-    padding-top: 44px;
+    padding-top: 0;
   }
 `;
 

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,8 +1,10 @@
 // styled.d.ts
-import 'styled-components';
+import "styled-components";
 
-declare module 'styled-components' {
+declare module "styled-components" {
   export interface DefaultTheme {
     width: number;
   }
 }
+
+export type BackgroundColor = "primary" | "secondary" | undefined;


### PR DESCRIPTION
### Summary
- 웹 로그인 팝업 다크모드 색상 수정
- 모바일 하단 네비게이션 아이콘, 배경 색 수정
- 설정 페이지 다크모드 적용 (웹, 모바일)
- 문의 글자 수 세기의 영역이 textArea를 벗어나지 않도록 수정
- 식당 순서 변경에서 글자 수가 영역을 벗어나지 않도록 수정 (글자 수가 넘어갈 경우 ... 처리)

### Tech
- 설정 페이지의 하위 페이지에서 배경 색상이 페이지에 따라 바뀌어야 하는 경우가 있어, useSelectedLayoutSegments를 사용해 하위 경로에 따라 색상이 바뀌도록 설정했습니다.
- 다크모드와 일반모드에서 색상이 고정되어야 하는 경우가 있어, 이 경우는 Color-Static으로 추가했습니다.