### PR TITLE
CSS 깨짐 현상 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,9 +54,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko" suppressHydrationWarning>
       <body>
-        <GlobalStyle />
         <ClientMixpanelInitializer />
         <StyledComponentsRegistry>
+          <GlobalStyle />
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
             <ContextProvider>
               <LikedMenusProvider>


### PR DESCRIPTION
### Summary

초기 접속 후 네비게이션 등을 통해 다른 페이지로 이동 시 CSS 깨짐 현상이 발생했었습니다. 이를 수정한 PR입니다.

### Tech

- <GlobalStyle> component를 <StyledComponentsRegistry> 안으로 이동시켜, 페이지 전환 과정에서 unmount 후 remount가 되지 않아 전역 스타일이 적용되지 않았었습니다.