### PR TITLE
CSS 깨짐 현상 수정 (2차)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { ModalsProvider } from "providers/ModalsProvider";
 import { LikedMenusProvider } from "providers/LikedMenusProvider";
 import ToastProvider from "providers/ToastProvider";
 import Script from "next/script";
-import { GlobalStyle } from "styles/globalstyle";
 import { ThemeProvider } from "next-themes";
 import Layout from "components/general/Layout";
 import { Suspense } from "react";
@@ -56,7 +55,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <ClientMixpanelInitializer />
         <StyledComponentsRegistry>
-          <GlobalStyle />
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
             <ContextProvider>
               <LikedMenusProvider>

--- a/src/providers/StyledComponentsRegistry.tsx
+++ b/src/providers/StyledComponentsRegistry.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useServerInsertedHTML } from "next/navigation";
 import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+import { GlobalStyle } from "styles/globalstyle";
 
 export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
   // Only create stylesheet once with lazy initial state
@@ -18,7 +19,13 @@ export default function StyledComponentsRegistry({ children }: { children: React
     return <>{styles}</>;
   });
 
-  if (typeof window !== "undefined") return <>{children}</>;
+  if (typeof window !== "undefined")
+    return (
+      <>
+        <GlobalStyle />
+        {children}
+      </>
+    );
 
   const StyleSheetManagerFixed = StyleSheetManager as unknown as React.ComponentType<{
     sheet: any;
@@ -27,6 +34,7 @@ export default function StyledComponentsRegistry({ children }: { children: React
 
   return (
     <StyleSheetManagerFixed sheet={styledComponentsStyleSheet.instance}>
+      <GlobalStyle />
       {children}
     </StyleSheetManagerFixed>
   );


### PR DESCRIPTION
### Summary

초기 접속 후 네비게이션 등을 통해 다른 페이지로 이동 시 CSS 깨짐 현상이 여전히 발생했었습니다. 이를 수정한 PR입니다.

### Tech

- 1차 수정(#266)에서 `<GlobalStyle>`을 `<StyledComponentsRegistry>`의 children으로 이동했으나, children은 Server Component(`layout.tsx`)가 생성하므로 네비게이션마다 새 React 엘리먼트로 교체되어 unmount가 여전히 발생했습니다.
- `<GlobalStyle>` component를 `<StyledComponentsRegistry>` 내부 render 함수에서 직접 렌더링하도록 이동시켜, 페이지 전환 과정에서 unmount 후 remount가 되지 않아 전역 스타일이 적용되지 않았었습니다.