### PR TITLE
바텀시트 라벨, 버튼 디자인 수정

### DIFF
--- a/src/app/components/MobileFilter/MobileFilterBottomSheet.tsx
+++ b/src/app/components/MobileFilter/MobileFilterBottomSheet.tsx
@@ -252,10 +252,14 @@ const StyledStarIcon = styled(StarFilledIcon)`
 
 export const FilterActionSection = styled.div<{ $marginBottom: string; $marginTop?: string }>`
   display: flex;
+  gap: 7px;
   padding-bottom: ${(props) => `${props.$marginBottom}px`};
   padding-top: ${(props) => `${props.$marginTop ?? 0}px`};
-  justify-content: space-between;
-  /* box-shadow: 0px -1px 6px 0px rgba(0, 0, 0, 0.05); */
+  box-shadow: 0px -1px 3px 0px rgba(0, 0, 0, 0.05);
+
+  & > button {
+    flex: 1;
+  }
 `;
 
 const FilterContentWrapper = styled.div`
@@ -289,11 +293,11 @@ const MobileFilterHeader = styled.div`
   justify-content: center;
   margin-bottom: 10.68px;
   align-items: center;
-  color: var(--SemanticColor-Text-GNB);
+  color: var(--Color-Foundation-base-black);
 `;
 
 export const MobileFilterText = styled.div`
   font-size: 16px;
   font-weight: 800;
-  color: var(--SemanticColor-Text-GNB);
+  color: var(--Color-Foundation-base-black);
 `;

--- a/src/components/general/Button.tsx
+++ b/src/components/general/Button.tsx
@@ -22,20 +22,26 @@ export default function Button({ children, onClick, variant = "primary", ...prop
   );
 }
 
-const NeutralButton = styled.button`
-  background-color: var(--SemanticColor-Background-Quaternary);
+const BaseButton = styled.button`
   color: var(--SemanticColor-Text-Button);
   padding: 10px 20px;
   height: 38px;
   flex-shrink: 0;
   border-radius: 20px;
+  border: none;
+  cursor: pointer;
+  font-family: var(--Font-family-sans, NanumSquare);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: -0.3px;
+  text-align: center;
 `;
 
-const PrimaryButton = styled.button`
+const NeutralButton = styled(BaseButton)`
+  background-color: var(--Color-Foundation-gray-500);
+`;
+
+const PrimaryButton = styled(BaseButton)`
   background-color: var(--Color-Foundation-orange-500);
-  color: var(--SemanticColor-Text-Button);
-  padding: 10px 20px;
-  height: 38px;
-  flex-shrink: 0;
-  border-radius: 20px;
 `;


### PR DESCRIPTION
### Summary

모바일 필터 바텀시트의 라벨 및 하단 버튼 디자인을 피그마와 맞도록 수정했습니다.

### Tech

- `FilterActionSection`의 버튼 레이아웃을 `space-between` 대신 `gap`과 `flex: 1`을 활용해 두 버튼이 동일한 너비로 배치되도록 변경하고, 상단 box-shadow를 적용했습니다.
- 바텀시트 헤더 텍스트 색상을 `--SemanticColor-Text-GNB`에서 `--Color-Foundation-base-black`으로 변경했습니다.
- `Button` 컴포넌트에서 `NeutralButton`/`PrimaryButton`이 중복으로 가지고 있던 스타일을 `BaseButton`으로 추출하고, 폰트/커서/border 등 누락되어 있던 공통 스타일을 함께 정리했습니다. `NeutralButton`의 배경색도 디자인 토큰(`--Color-Foundation-gray-500`)으로 교체했습니다.