### PR TITLE
식당 순서 변경 카드 폰트/디자인, 식당 이름 표시, 순서 저장 문제 수정

### DIFF
--- a/src/app/account/restaurant/favorite/page.tsx
+++ b/src/app/account/restaurant/favorite/page.tsx
@@ -15,9 +15,9 @@ import useError from "hooks/useError";
 export default function FavoriteOrderSetting() {
   const { authStatus, authGuard } = useAuth();
   const router = useRouter();
-  const { orderList, setNewOrderList } = useOrder("favorite");
+  const { orderList, setNewOrderList, getStoredOrderList } = useOrder("favorite");
 
-  const { favoriteRestaurants } = useFavorite();
+  const { getStoredFavorites } = useFavorite();
 
   const { onHttpError } = useError();
 
@@ -26,26 +26,26 @@ export default function FavoriteOrderSetting() {
   useEffect(() => {
     getRestaurantList()
       .then((result) => {
-        // 1. localStorage에는 있는데, 받아온 데이터에는 없는 식당은 remove
+        const storedOrder = getStoredOrderList();
+        const favorites = getStoredFavorites();
+        const apiById = new Map(result.map((restaurant) => [restaurant.id, restaurant]));
+        const isFavorite = (id: number) => apiById.has(id) && favorites.includes(id);
 
-        let ghostRestaurantIds: number[] = [];
-        orderList.forEach((res) => {
-          if (!result.find(({ id }) => id === res.id) || !favoriteRestaurants.includes(res.id)) {
-            ghostRestaurantIds = [...ghostRestaurantIds, res.id];
-          }
-        });
+        // 1. 저장된 순서 유지 + (사라졌거나 즐겨찾기 해제된) 식당 제거 + 이름은 API 기준으로 갱신
+        const ordered: RestaurantPreview[] = storedOrder
+          .filter((res) => isFavorite(res.id))
+          .map(({ id }) => {
+            const { nameKr, nameEn } = apiById.get(id)!;
+            return { id, nameKr, nameEn };
+          });
 
-        const newOrderList = orderList.filter((res) => !ghostRestaurantIds.includes(res.id));
+        // 2. 즐겨찾기에 새로 추가된 식당을 뒤에 추가
+        const orderedIds = new Set(ordered.map((res) => res.id));
+        const appended: RestaurantPreview[] = result
+          .filter(({ id }) => isFavorite(id) && !orderedIds.has(id))
+          .map(({ id, nameKr, nameEn }) => ({ id, nameKr, nameEn }));
 
-        // 2. localStorage에 없고, 받아온 데이터에 있는 식당을 추가
-        let newRestaurants: RestaurantPreview[] = [];
-        result.forEach(({ id, nameKr, nameEn }) => {
-          if (!newOrderList.find((res) => res.id === id) && favoriteRestaurants.includes(id)) {
-            newRestaurants = [...newRestaurants, { id, nameKr, nameEn }];
-          }
-        });
-
-        setNewOrderList([...newOrderList, ...newRestaurants]);
+        setNewOrderList([...ordered, ...appended]);
       })
       .catch(onHttpError);
   }, []);

--- a/src/app/account/restaurant/page.tsx
+++ b/src/app/account/restaurant/page.tsx
@@ -14,7 +14,7 @@ import useError from "hooks/useError";
 export default function NonFavoriteOrderSetting() {
   const { authStatus, authGuard } = useAuth();
   const router = useRouter();
-  const { orderList, setNewOrderList } = useOrder("nonFavorite");
+  const { orderList, setNewOrderList, getStoredOrderList } = useOrder("nonFavorite");
 
   const { onHttpError } = useError();
 
@@ -23,25 +23,24 @@ export default function NonFavoriteOrderSetting() {
   useEffect(() => {
     getRestaurantList()
       .then((result) => {
-        // 1. localStorage에는 있는데, 받아온 데이터에는 없는 식당은 remove
-        let ghostRestaurantIds: number[] = [];
-        orderList.forEach((res) => {
-          if (!result.find(({ id }) => id === res.id)) {
-            ghostRestaurantIds = [...ghostRestaurantIds, res.id];
-          }
-        });
+        const storedOrder = getStoredOrderList();
+        const apiById = new Map(result.map((restaurant) => [restaurant.id, restaurant]));
 
-        const newOrderList = orderList.filter((res) => !ghostRestaurantIds.includes(res.id));
+        // 1. 저장된 순서 유지 + 사라진 식당 제거 + 이름은 API 기준으로 갱신
+        const ordered: RestaurantPreview[] = storedOrder
+          .filter((res) => apiById.has(res.id))
+          .map(({ id }) => {
+            const { nameKr, nameEn } = apiById.get(id)!;
+            return { id, nameKr, nameEn };
+          });
 
-        // 2. localStorage에 없고, 받아온 데이터에 있는 식당을 추가
-        let newRestaurants: RestaurantPreview[] = [];
-        result.forEach(({ id, nameKr, nameEn }) => {
-          if (!newOrderList.find((res) => res.id === id)) {
-            newRestaurants = [...newRestaurants, { id, nameKr, nameEn }];
-          }
-        });
+        // 2. 저장된 순서엔 없지만 API엔 있는 새 식당을 뒤에 추가
+        const orderedIds = new Set(ordered.map((res) => res.id));
+        const appended: RestaurantPreview[] = result
+          .filter(({ id }) => !orderedIds.has(id))
+          .map(({ id, nameKr, nameEn }) => ({ id, nameKr, nameEn }));
 
-        setNewOrderList([...newOrderList, ...newRestaurants]);
+        setNewOrderList([...ordered, ...appended]);
       })
       .catch(onHttpError);
   }, []);

--- a/src/components/Account/RestaurantOrderEditor.tsx
+++ b/src/components/Account/RestaurantOrderEditor.tsx
@@ -122,9 +122,9 @@ const DragBox = styled.div<{ $dragging: boolean }>`
   display: flex;
   justify-content: space-between;
   width: 499.04px;
-  height: 49px;
+  height: 50px;
   border: 1px solid var(--Color-Foundation-gray-200);
-  border-radius: 8px;
+  border-radius: 12px;
   margin: 7.92px 22.15px;
   background-color: ${(props) =>
     props.$dragging ? "var(--Color-Foundation-gray-50)" : "var(--SemanticColor-Element-Tooltip2)"};;
@@ -140,6 +140,7 @@ const Restaurant = styled.p`
   font-weight: 400;
   font-size: 16px;
   line-height: 23px;
+  color: var(--Color-Foundation-gray-800);
 
   overflow: hidden;
   text-overflow: ellipsis;
@@ -160,7 +161,7 @@ const DragButton = styled.div<{ $dragging: boolean }>`
   width: 34px;
   height: 34px;
   background-color: ${(props) =>
-    props.$dragging ? "var(--Color-Foundation-orange-500)" : "var(--Color-Foundation-gray-300)"};
+    props.$dragging ? "var(--Color-Foundation-orange-500)" : "var(--Color-Foundation-gray-200)"};
   border-radius: 8px;
   margin: 7.5px;
 `;

--- a/src/hooks/UseFavorite.ts
+++ b/src/hooks/UseFavorite.ts
@@ -11,6 +11,12 @@ export default function useFavorite() {
   // localStorage가 구독되어 변화를 감지하므로, 따로 state를 만들어주기 보다는 JSON parse 결과를 바로 이용해야 합니다.
   const favoriteRestaurants: number[] = JSON.parse(value || "[]");
 
+  // 하이드레이션 클로저에 갇히지 않도록 최신 저장값을 직접 읽는다.
+  function getStoredFavorites(): number[] {
+    if (typeof window === "undefined") return [];
+    return JSON.parse(localStorage.getItem("favorite_restaurant") || "[]");
+  }
+
   const toggleFavorite = (restaurantId: number) => {
     if (authStatus === "logout") openLoginModal();
     else {
@@ -25,5 +31,5 @@ export default function useFavorite() {
 
   const isFavorite = (restaurantId: number) => favoriteRestaurants.includes(restaurantId);
 
-  return { favoriteRestaurants, toggleFavorite, isFavorite };
+  return { favoriteRestaurants, toggleFavorite, isFavorite, getStoredFavorites };
 }

--- a/src/hooks/UseOrder.ts
+++ b/src/hooks/UseOrder.ts
@@ -12,5 +12,11 @@ export default function useOrder(type: "favorite" | "nonFavorite") {
     setStorage(JSON.stringify(newOrderList));
   }
 
-  return { orderList, setNewOrderList };
+  // 하이드레이션 클로저에 갇히지 않도록 최신 저장값을 직접 읽는다.
+  function getStoredOrderList(): RestaurantPreview[] {
+    if (typeof window === "undefined") return [];
+    return JSON.parse(localStorage.getItem(key) || "[]");
+  }
+
+  return { orderList, setNewOrderList, getStoredOrderList };
 }

--- a/src/utils/api/restaurants.ts
+++ b/src/utils/api/restaurants.ts
@@ -3,14 +3,16 @@ import APIendpoint from "constants/constants";
 import { Restaurant, RawRestaurant } from "types";
 
 export const getRestaurantList = (): Promise<Restaurant[]> => {
-  const parse = (rawData: RawRestaurant[]): Restaurant[] =>
+  // `/restaurants` 엔드포인트는 식당 이름을 camelCase(nameKr/nameEn)로 반환한다.
+  // (`/menus`의 식당 데이터는 snake_case라 RawRestaurant와 함께 fallback으로 둔다.)
+  const parse = (rawData: (RawRestaurant & Partial<Restaurant>)[]): Restaurant[] =>
     rawData.map((restaurant) => ({
       createdAt: restaurant.created_at,
       updatedAt: restaurant.updated_at,
       id: restaurant.id,
       code: restaurant.code,
-      nameKr: restaurant.name_kr,
-      nameEn: restaurant.name_en,
+      nameKr: restaurant.nameKr ?? restaurant.name_kr,
+      nameEn: restaurant.nameEn ?? restaurant.name_en,
       addr: restaurant.addr,
       lat: restaurant.lat,
       lng: restaurant.lng,


### PR DESCRIPTION
### Summary

식당 순서 변경(즐겨찾기 포함) 화면의 카드에서 발생하던 세 가지 문제를 수정하고, 카드 디자인을 피그마와 맞도록 정렬했습니다.

1. 식당 이름이 라이트 모드에서 흰색으로 보이지 않던 문제
2. 식당 이름 자체가 빈 칸으로 표시되던 문제
3. 드래그로 바꾼 순서가 새로고침 후 초기화되던 문제

### Tech

- **폰트 색상**: `Restaurant` 텍스트에 `color`가 지정되어 있지 않아 흰색을 상속받던 문제를, 디자인 토큰 `--Color-Foundation-gray-800`(라이트 `#4C4D50` / 다크 `#CBCBCC`)으로 지정하여 라이트·다크 모드 모두에서 잘 보이도록 수정했습니다.
- **빈 식당 이름**: `/restaurants` 엔드포인트는 식당 이름을 camelCase(`nameKr`/`nameEn`)로 반환하는데, `getRestaurantList` 파서가 snake_case(`name_kr`/`name_en`)로 읽고 있어 `nameKr`이 `undefined`가 되어 카드 이름이 빈 칸으로 표시되던 문제를 수정했습니다. (`/menus` 데이터는 snake_case이므로 `RawRestaurant`와 함께 fallback으로 유지)
- **순서 초기화**: `useSyncExternalStore` 값이 하이드레이션 시점(`getServerSnapshot`)에 빈 배열로 시작해, 마운트 시 한 번 도는 머지 `effect`의 클로저가 빈 `orderList`/`favorite`를 캡처하면서 저장된 순서를 API 기본 순서로 덮어쓰던 문제를 수정했습니다. effect에서는 `localStorage`를 직접 읽도록 `getStoredOrderList`/`getStoredFavorites`를 추가하고, 머지 로직을 (순서 유지 + 사라진/즐겨찾기 해제된 식당 제거 + API 기준으로 이름 갱신 + 새 식당 추가)로 정리했습니다.
- **디자인 정렬**: `DragBox`의 `border-radius`를 `8px → 12px`, `height`를 `49px → 50px`로 조정하고, 드래그 핸들(`DragButton`)의 기본 배경색을 `--Color-Foundation-gray-300`에서 `--Color-Foundation-gray-200`으로 교체했습니다.

**Note**: 이 PR은 수정된 디자인(식당 순서 변경(26.04))을 반영하지 **않고**, 기존 웹사이트의 문제만 수정하는 PR입니다.