### PR TITLE
필터 카드 레이아웃 개편 및 버그 수정

### DIFF
--- a/src/app/components/RestaurantFilter.tsx
+++ b/src/app/components/RestaurantFilter.tsx
@@ -1,5 +1,8 @@
 import UseFilter from "hooks/UseFilter";
 import useIsExceptEmpty from "hooks/UseIsExceptEmpty";
+import useAuth from "hooks/UseAuth";
+import useModals from "hooks/UseModals";
+import { useStateContext, useDispatchContext } from "providers/ContextProvider";
 import "rc-slider/assets/index.css";
 import "styles/slider.css";
 import { useCallback, useEffect, useState } from "react";
@@ -18,6 +21,18 @@ import { AnalyticsEvent, EventNames } from "constants/track";
 export default function RestaurantFilter() {
   const { filterList, setFilterList, resetFilterList, countChangedFilters } = UseFilter();
   const { isExceptEmpty, toggleIsExceptEmpty } = useIsExceptEmpty();
+  const { isFilterFavorite } = useStateContext();
+  const { setIsFilterFavorite } = useDispatchContext();
+  const { authStatus } = useAuth();
+  const { openLoginModal } = useModals();
+
+  const handleToggleFavorite = () => {
+    if (authStatus === "logout") {
+      openLoginModal();
+      return;
+    }
+    setIsFilterFavorite(!isFilterFavorite);
+  };
   const { length, priceMin, priceMax, ratingMin, isReview, isAvailableOnly } = filterList;
 
   const [selectedFilters, setSelectedFilters] = useState({
@@ -136,10 +151,12 @@ export default function RestaurantFilter() {
     <Container>
       <Header>
         <Title>메뉴 필터</Title>
-        <RefreshBox onClick={resetFilter}>
-          <StyledRefreshIcon />
-          <RefreshText>초기화</RefreshText>
-        </RefreshBox>
+        <FavoriteToggleWrapper onClick={handleToggleFavorite}>
+          <FavoriteToggleLabel>즐겨찾기한 식당만 보기</FavoriteToggleLabel>
+          <ToggleTrack $active={isFilterFavorite}>
+            <ToggleKnob $active={isFilterFavorite} />
+          </ToggleTrack>
+        </FavoriteToggleWrapper>
       </Header>
       <Filter>
         <SliderBox>
@@ -226,7 +243,13 @@ export default function RestaurantFilter() {
           </ButtonGroup>
         </ContentBar>
       </Filter>
-      <DecideButton onClick={applyFilter}>필터 적용하기</DecideButton>
+      <ButtonRow>
+        <ResetButton onClick={resetFilter}>
+          <StyledRefreshIcon />
+          <RefreshText>초기화</RefreshText>
+        </ResetButton>
+        <DecideButton onClick={applyFilter}>필터 적용하기</DecideButton>
+      </ButtonRow>
     </Container>
   );
 }
@@ -255,11 +278,46 @@ const Title = styled.h3`
   line-height: 140%; /* 22.4px */
 `;
 
-const RefreshBox = styled.div`
+const FavoriteToggleWrapper = styled.div`
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   cursor: pointer;
+`;
+
+const FavoriteToggleLabel = styled.span`
+  color: var(--Color-Foundation-gray-600, #989aa0);
+  font-size: var(--Font-size-13, 13px);
+  font-weight: var(--Font-weight-bold, 700);
+  line-height: 140%; /* 18.2px */
+  white-space: nowrap;
+`;
+
+const ToggleTrack = styled.div<{ $active: boolean }>`
+  position: relative;
+  flex-shrink: 0;
+  width: 23px;
+  height: 14.056px;
+  border-radius: 59.14px;
+  background: ${(props) =>
+    props.$active
+      ? "var(--Color-Foundation-orange-500, #ff9522)"
+      : "var(--SemanticColor-Icon-GrayIcon, #bec1c8)"};
+  transition: background 0.2s ease-out;
+`;
+
+const ToggleKnob = styled.div<{ $active: boolean }>`
+  position: absolute;
+  top: 50%;
+  right: ${(props) => (props.$active ? "1.5px" : "10.22px")};
+  transform: translateY(-50%);
+  width: 11.5px;
+  height: 11.5px;
+  border-radius: 50%;
+  background: var(--Color-Static-White, #fff);
+  box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.04), 0px 1.233px 3.288px 0px rgba(0, 0, 0, 0.15),
+    0px 1.233px 0.411px 0px rgba(0, 0, 0, 0.06);
+  transition: right 0.2s ease-out;
 `;
 
 const StyledRefreshIcon = styled(RefreshIcon)`
@@ -269,10 +327,10 @@ const StyledRefreshIcon = styled(RefreshIcon)`
 `;
 
 const RefreshText = styled.span`
-  color: var(--Color-Foundation-gray-800, #4c4d50);
-  font-size: var(--Font-size-13, 13px);
+  color: var(--Color-Foundation-gray-600, #989aa0);
+  font-size: var(--Font-size-14, 14px);
   font-weight: var(--Font-weight-bold, 700);
-  line-height: 140%; /* 18.2px */
+  line-height: 150%; /* 21px */
 `;
 
 const Filter = styled.div`
@@ -344,14 +402,36 @@ const FilterButton = styled.button<{ $active?: boolean }>`
   text-align: center;
 `;
 
+const ButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  align-self: stretch;
+  width: 100%;
+`;
+
+const ResetButton = styled.button`
+  display: flex;
+  flex: 1 0 0;
+  height: 42px;
+  padding: 0;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  border-radius: 8px;
+  border: 1px solid var(--Color-Foundation-gray-300, #d8dade);
+  background: var(--SemanticColor-Background-Quaternary);
+  cursor: pointer;
+`;
+
 const DecideButton = styled.button`
   display: flex;
+  flex: 1 0 0;
   height: 42px;
-  padding: 0px 65px;
   justify-content: center;
   align-items: center;
   gap: 10px;
-  align-self: stretch;
   border-radius: 8px;
   background: var(--Color-Foundation-orange-500, #ff9522);
 

--- a/src/app/components/RestaurantFilter.tsx
+++ b/src/app/components/RestaurantFilter.tsx
@@ -151,7 +151,12 @@ export default function RestaurantFilter() {
     <Container>
       <Header>
         <Title>메뉴 필터</Title>
-        <FavoriteToggleWrapper onClick={handleToggleFavorite}>
+        <FavoriteToggleWrapper
+          type="button"
+          role="switch"
+          aria-checked={isFilterFavorite}
+          onClick={handleToggleFavorite}
+        >
           <FavoriteToggleLabel>즐겨찾기한 식당만 보기</FavoriteToggleLabel>
           <ToggleTrack $active={isFilterFavorite}>
             <ToggleKnob $active={isFilterFavorite} />
@@ -278,7 +283,7 @@ const Title = styled.h3`
   line-height: 140%; /* 22.4px */
 `;
 
-const FavoriteToggleWrapper = styled.div`
+const FavoriteToggleWrapper = styled.button`
   display: flex;
   align-items: center;
   gap: 6px;

--- a/src/app/components/RestaurantList.tsx
+++ b/src/app/components/RestaurantList.tsx
@@ -19,7 +19,7 @@ function scrollRestaurant(restaurant) {
 export default function RestaurantList() {
   const state = useStateContext();
 
-  const { meal, data } = state;
+  const { meal, data, isFilterFavorite } = state;
 
   const { favoriteRestaurants, toggleFavorite, isFavorite } = useFavorite();
 
@@ -40,9 +40,15 @@ export default function RestaurantList() {
     const favorites = restaurants.filter((restaurant) => isFavorite(restaurant.id));
     const nonFavorites = restaurants.filter((restaurant) => isFavorite(restaurant.id) === false);
 
-    const newFavoriteFirstRestaurants = favorites.concat(nonFavorites);
+    const newFavoriteFirstRestaurants = isFilterFavorite
+      ? favorites
+      : favorites.concat(nonFavorites);
     setFavoriteFirstRestaurants(newFavoriteFirstRestaurants);
-  }, [data, meal, favoriteRestaurants.length]);
+  }, [data, meal, favoriteRestaurants.length, isFilterFavorite]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [isFilterFavorite]);
 
   return (
     <Container $show={(data[meal] || []).length >= 1}>

--- a/src/app/components/WebPicket.tsx
+++ b/src/app/components/WebPicket.tsx
@@ -11,20 +11,19 @@ interface PicketProps {
 export default function WebPicket({ bodyPos, tailPos, text, ref }: PicketProps) {
   return (
     <>
-      <PicketBox $left={bodyPos ?? 0} ref={ref}>
+      <PicketBox style={{ left: `${bodyPos ?? 0}%` }} ref={ref}>
         <PicketText>{text}</PicketText>
       </PicketBox>
-      <StyledPicketBottom $left={tailPos ?? 0} />
+      <StyledPicketBottom style={{ left: `${tailPos ?? 0}%` }} />
     </>
   );
 }
 
-const PicketBox = styled.div<{ $left: number }>`
+const PicketBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   position: absolute;
-  left: ${(props) => `${props.$left}%`};
   transform: translateX(-50%);
   top: -30px;
 `;
@@ -47,9 +46,8 @@ const PicketText = styled.div`
   white-space: nowrap;
 `;
 
-const StyledPicketBottom = styled(PicketBottomIcon)<{ $left: number }>`
+const StyledPicketBottom = styled(PicketBottomIcon)`
   position: absolute;
-  left: ${(props) => `${props.$left}%`}; // hardcoded 3px to center the image
   transform: translateX(-50%);
   top: -11.5px;
   width: 6px;

--- a/src/app/components/WebPicket.tsx
+++ b/src/app/components/WebPicket.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import styled from "styled-components";
 import PicketBottomIcon from "assets/icons/picket-bottom.svg";
 
@@ -5,10 +6,12 @@ interface PicketProps {
   bodyPos?: number;
   tailPos?: number;
   text: string;
-  ref?: React.RefObject<HTMLDivElement>;
 }
 
-export default function WebPicket({ bodyPos, tailPos, text, ref }: PicketProps) {
+const WebPicket = forwardRef<HTMLDivElement, PicketProps>(function WebPicket(
+  { bodyPos, tailPos, text },
+  ref,
+) {
   return (
     <>
       <PicketBox style={{ left: `${bodyPos ?? 0}%` }} ref={ref}>
@@ -17,7 +20,9 @@ export default function WebPicket({ bodyPos, tailPos, text, ref }: PicketProps) 
       <StyledPicketBottom style={{ left: `${tailPos ?? 0}%` }} />
     </>
   );
-}
+});
+
+export default WebPicket;
 
 const PicketBox = styled.div`
   display: flex;

--- a/src/components/general/Layout.tsx
+++ b/src/components/general/Layout.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import Header from "components/general/Header";
-import { useDispatchContext } from "providers/ContextProvider";
 import useAuth from "hooks/UseAuth";
-import useIsMobile from "hooks/UseIsMobile";
 import UseProfile from "hooks/UseProfile";
 import React, { useEffect } from "react";
 import styled from "styled-components";
@@ -23,8 +21,6 @@ export default function Layout({ children }: LayoutProps) {
   const boardId = searchParams?.get("boardId");
   const pathname = usePathname();
 
-  const { setIsFilterFavorite } = useDispatchContext();
-  const isMobile = useIsMobile();
   const { getAccessToken, login } = useAuth();
 
   UseProfile();
@@ -40,10 +36,6 @@ export default function Layout({ children }: LayoutProps) {
         if (message !== "Login required") console.error(error);
       });
   }, []);
-
-  useEffect(() => {
-    if (!isMobile) setIsFilterFavorite(false);
-  }, [isMobile]);
 
   useEffect(() => {
     if (analytics) {

--- a/src/hooks/UseAuth.ts
+++ b/src/hooks/UseAuth.ts
@@ -6,7 +6,7 @@ import useLocalStorage from "./UseLocalStorage";
 
 export default function useAuth() {
   const { authStatus } = useStateContext();
-  const { setAuthStatus } = useDispatchContext();
+  const { setAuthStatus, setIsFilterFavorite } = useDispatchContext();
   const { openLoginModal } = useModals();
   const router = useRouter();
 
@@ -15,6 +15,9 @@ export default function useAuth() {
     set: setStorage,
     remove: removeStorage,
   } = useLocalStorage("access_token", undefined);
+
+  const { remove: removeFavoriteStorage } = useLocalStorage("favorite_restaurant", "[]");
+  const { remove: removeFilterStorage } = useLocalStorage("filterList", "{}");
 
   // TODO: 안티패턴이므로 수정 필요
   // 전역적으로 수행되어야 하는 동작이 useAuth 내 useEffect의 callback function으로 들어가 있음
@@ -71,8 +74,11 @@ export default function useAuth() {
 
   const logout = useCallback(() => {
     removeStorage();
+    removeFavoriteStorage();
+    removeFilterStorage();
+    setIsFilterFavorite(false);
     setAuthStatus("logout");
-  }, [removeStorage, setAuthStatus]);
+  }, [removeStorage, removeFavoriteStorage, removeFilterStorage, setIsFilterFavorite, setAuthStatus]);
 
   return { authStatus, authGuard, getAccessToken, checkAccessToken, login, logout };
 }

--- a/src/hooks/UseFilter.ts
+++ b/src/hooks/UseFilter.ts
@@ -94,9 +94,8 @@ export default function UseFilter() {
    * 필터 리스트를 초기화합니다. (축제 토글 제외)
    */
   const resetFilterList = () => {
-    const oldIsFestival = filterList.isFestival;
-    setStorage(defaultFiltersJson);
-    changeFilterOption({ isFestival: oldIsFestival });
+    const newFilters = { ...defaultFilters, isFestival: filterList.isFestival };
+    setStorage(JSON.stringify(newFilters, replacer));
   };
 
   /**


### PR DESCRIPTION
### Summary

메인 화면 좌측 필터 카드를 개편하고, 작업 중 발견한 관련 버그들을 함께 수정했습니다.

- 필터 카드 레이아웃 개편
  - "즐겨찾기한 식당만 보기" 토글 추가 및 로그아웃 상태에서 토글 시 로그인 모달
  - 필터 적용하기 → 초기화 + 필터 적용하기
- 버그 수정
  - 초기화 클릭이 즉시 반영되지 않던 문제
  - 거리/가격 슬라이더 드래그 시 전체 폰트가 깜빡이던 문제
  - 로그아웃해도 즐겨찾기 및 필터가 남던 문제

### Tech

1. 메인 필터 카드 하단 버전 전환
- `RestaurantFilter.tsx:` 헤더 토글 및 하단 `ButtonRow` 신설. 
- 기존 전역 상태 `isFilterFavorite` 재사용. 로그아웃 상태면 `openLoginModal()`.
- `Layout.tsx`: 데스크톱에서 `isFilterFavorite`를 강제로 끄던 코드 제거 ⇒ 데스크톱 토글 활성화.

2. 필터 초기화가 즉시 적용되지 않던 버그 수정
- `UseFilter.ts`의 `resetFilterList`: `setStorage(defaults)` 직후 `changeFilterOption`이 렌더 시점의 이전 `filterList`를 spread해 초기화를 되돌리던 문제. ⇒ `{ ...defaultFilters, isFestival }`를 한 번의 write로 저장하도록 수정.

3. 슬라이더 드래그 시 전체 폰트 깜빡임 제거
- `WebPicket.tsx`: 드래그마다 연속 변하는 `left` 값을 styled-components 템플릿에 주입 → 같은 시트의 `@font-face`가 재평가되어 전체 폰트가 fallback으로 깜빡임. ⇒ inline `style`로 전달해 클래스 재생성 제거.

4. 로그아웃 시 즐겨찾기 및 필터 초기화
- `UseAuth.ts`의 `logout()`: 기존 `access_token` 삭제에 더해 `favorite_restaurant`, `filterList` localStorage 삭제 + `setIsFilterFavorite(false)`